### PR TITLE
Create MapaCrimen2011Completo.csv

### DIFF
--- a/text_processing/data/narco/MapaCrimen2011Completo.csv
+++ b/text_processing/data/narco/MapaCrimen2011Completo.csv
@@ -1,0 +1,963 @@
+Año, Día, Latitud, Longitud, Título, Muertos, Heridos, Detenidos, Liberados, Decomisos
+2011, 18 de Diciembre  ,25.647326,-100.094528, Tiran en Ju&#225;rez a dos ejecutados ,0,0,0,0,0
+2011, 8 de Diciembre  ,25.647326,-100.094528, Caen 18 de narcobanda ,0,0,0,0,0
+2011, 5 de Diciembre  ,25.701272,-100.300687, Matan a hombre luego de bajarlo de un veh&#237;culo ,0,0,0,0,0
+2011, 22 de Diciembre  ,25.710743,-100.346983, Asesinan de dos balazos a gerente de refaccionaria ,0,0,0,0,0
+2011, 21 de Diciembre  ,25.64786,-100.274847, Lo ejecutan de 4 tiros afuera del Santa Luc&#237;a ,0,0,0,0,0
+2011, 16 de Diciembre  ,25.663452,-100.281747, Ejecutan a una pareja y la encajuelan en  ,0,0,0,0,0
+2011, 12 de Diciembre  ,25.708256,-100.320322, Acribillan a pareja ,0,0,0,0,0
+2011, 12 de Diciembre  ,25.673211,-100.309201, Lo tiran de un auto y ejecutan ,0,0,0,0,0
+2011, 8 de Diciembre  ,25.71412,-100.242747, Corren a vecinas para cometer ejecuci&#243;n ,0,0,0,0,0
+2011, 8 de Diciembre  ,25.605347,-100.267797, Balean frente a Sedena a 3 con veh&#237;culo robado ,0,0,0,0,0
+2011, 5 de Diciembre  ,25.738467,-100.407831, Balean a abogado en Avenida Leones ,0,0,0,0,0
+2011, 22 de Diciembre  ,25.647005,-100.26743, Torturan ejecutan y tiran cuerpos ,0,0,0,0,0
+2011, 20 de Diciembre  ,25.712011,-100.194841, Persiguen y matan a menor de 16 a&#241;os ,0,0,0,0,0
+2011, 19 de Diciembre  ,25.686984,-100.209134, Ejecutan en taxi a dos hermanos ,0,0,0,0,0
+2011, 5 de Diciembre  ,25.647005,-100.26743, Matan a balazos y pedradas a dos ,0,0,0,0,0
+2011, 22 de Diciembre  ,25.772789,-100.266322, Busca latas en un arroyo y encuentra un calcinado ,0,0,0,0,0
+2011, 21 de Diciembre  ,25.803929,-100.352596, Le queman casa luego lo decapitan ,0,0,0,0,0
+2011, 8 de Diciembre  ,25.800237,-100.416357, Localizan en brecha a hombre ejecutado ,0,0,0,0,0
+2011, 4 de Diciembre  ,25.892745,-100.106047, Hallan en fosas restos humanos ,0,0,0,0,0
+2011, 18 de Diciembre  ,25.955113,-100.163749, Levantan a vecino; asesinan a ni&#241;o de siete a&#241;os ,0,0,0,0,0
+2011, 12 de Diciembre  ,25.936697,-100.362373, Hallan a tres ejecutados en El Carmen ,0,0,0,0,0
+2011, 17 de Diciembre  ,24.100739,-99.817931, Mata a conductor por reclamo vial ,0,0,0,0,0
+2011, 5 de Diciembre  ,25.808921,-100.597923, Ejecutan a mujer de 7 tiros ,0,0,0,0,0
+2011, 21 de Diciembre  ,25.470119,-100.189937, Ejecutan a ex tr&#225;nsito en Santiago ,0,0,0,0,0
+2011, 17 de Diciembre  ,25.183496,-99.829679, Lo ejecutan de 6 balazos ,0,0,0,0,0
+2011, 4 de Diciembre  ,25.183496,-99.829679, Asesinan a 4 y los queman en camioneta ,0,0,0,0,0
+2011, 25 de Diciembre  ,25.593517,-99.990181, Ejecutan a una mujer en Cadereyta ,0,0,0,0,0
+2011, 20 de Diciembre  ,25.593517,-99.990181, Torturan y ejecutan a uno en Cadereyta ,0,0,0,0,0
+2011, 5 de Diciembre  ,25.564538,-100.021283, Encuentran enterrado a un joven ejecutado ,0,0,0,0,0
+2011, 5 de Diciembre  ,26.506905,-100.179453, Abaten a uno en Sabinas ,0,0,0,0,0
+2011, 9 de Noviembre  ,25.87652,-100.027537, Calcinan un cuerpo en quinta de Mar&#237;n ,0,0,0,0,0
+2011, 6 de Noviembre  ,25.680313,-100.41788, Tiran en plaza a un decapitado ,1,0,0,0,0
+2011, 1 de Noviembre  ,25.659734,-100.369704, Hallan en un bald&#237;o a hombre muerto ,0,0,0,0,0
+2011, 16 de Noviembre  ,25.616293,-100.139743, Tiran en noria de una quinta a 2 ejecutados ,0,0,0,0,0
+2011, 23 de Noviembre  ,25.683677,-100.289651, Capturan a 5 menores con 170 dosis de droga ,0,0,0,0,0
+2011, 17 de Noviembre  ,25.726466,-100.255368, Cae a balazos un ex polic&#237;a de Apodaca ,0,0,0,0,0
+2011, 5 de Noviembre  ,25.770252,-100.27256, Detienen a 3 en tiroteo tras fallar un secuestro ,0,0,3,0,0
+2011, 2 de Noviembre  ,25.75,-100.283333, Lo ejecutan al salir de plaza comercial ,0,0,0,0,0
+2011, 2 de Noviembre  ,25.723983,-100.214796, Lo ejecutan al salir de plaza comercial ,1,0,0,0,0
+2011, 28 de Noviembre  ,25.668461,-100.314338, Balean a inocentes en levant&#243;n ,0,0,0,0,0
+2011, 28 de Noviembre  ,25.617215,-100.283851, Desatan tres menores persecuci&#243;n y p&#225;nico ,0,0,0,0,0
+2011, 27 de Noviembre  ,25.686223,-100.317814, Ejecutan a joven en Col&#243;n ,0,0,0,0,0
+2011, 27 de Noviembre  ,25.676341,-100.304596, Tiran cuerpo en el Centro ,0,0,0,0,0
+2011, 23 de Noviembre  ,25.676005,-100.321119, Suplica por su vida; sicarios la ejecutan ,0,0,0,0,0
+2011, 20 de Noviembre  ,25.66876,-100.338145, Ejecutan a mujer en caf&#233; del Centro ,0,0,0,0,0
+2011, 20 de Noviembre  ,25.686707,-100.324702, Matan en bar a una mesera de un balazo ,0,0,0,0,0
+2011, 17 de Noviembre  ,25.691884,-100.314008, Ejecutan a mesero afuera de un bar ,0,0,0,0,0
+2011, 17 de Noviembre  ,25.691347,-100.280345, Matan pistoleros a un polic&#237;a regio ,0,0,0,0,0
+2011, 16 de Noviembre  ,25.774941,-100.361556, Ejecutan a 2 j&#243;venes en Col. Tiro al Blanco ,0,0,0,0,0
+2011, 16 de Noviembre  ,25.75397,-100.376459, Balean a otro; muere en el hospital ,0,0,0,0,0
+2011, 12 de Noviembre  ,25.685498,-100.319874, Ejecutan a 2 junto a puesto ,2,0,0,0,0
+2011, 11 de Noviembre  ,25.65872,-100.317516, Matan en balacera a menor inocente ,0,0,0,0,0
+2011, 11 de Noviembre  ,25.683245,-100.286305, Persiguen y ejecutan a un narcodistribuidor ,0,0,0,0,0
+2011, 10 de Noviembre  ,25.645435,-100.290932, Lo matan a golpes por no dar cuota ,0,0,0,0,0
+2011, 8 de Noviembre  ,25.641291,-100.286063, Ejecutan a un polic&#237;a estatal ,1,1,0,0,0
+2011, 7 de Noviembre  ,25.680538,-100.322428, Lo ejecutan en el Centro ,1,0,0,0,0
+2011, 7 de Noviembre  ,25.647968,-100.307064, Arrollan a hombre tras una balacera ,1,0,0,0,0
+2011, 6 de Noviembre  ,25.736122,-100.359786, Someten a joven para ejecutarlo ,1,0,0,0,0
+2011, 5 de Noviembre  ,25.705259,-100.278976, Ejecutan sicarios a plagiado ,1,0,0,0,0
+2011, 1 de Noviembre  ,25.65872,-100.317516, Matan a cinco; otro huye ,0,0,0,0,0
+2011, 19 de Noviembre  ,25.717894,-100.260273, Mueren tres al enfrentar a militares ,0,0,0,0,0
+2011, 29 de Noviembre  ,25.690052,-100.190334, Ejecutan a primos afuera de su casa ,4,1,0,0,0
+2011, 23 de Noviembre  ,25.652861,-100.169801, Lo asesinan de 2 balazos ,0,0,0,0,0
+2011, 13 de Noviembre  ,25.694883,-100.192417, Hallan a muerto dentro de taxi ,0,0,0,0,0
+2011, 12 de Noviembre  ,25.723596,-100.191922, Acribillan a pareja en auto ,2,0,0,0,0
+2011, 8 de Noviembre  ,25.690593,-100.232241, Ejecutan a tres; balean a un ni&#241;o ,3,1,0,0,0
+2011, 2 de Noviembre  ,25.700586,-100.16647, Disparan y matan desde auto ,0,0,0,0,0
+2011, 2 de Noviembre  ,25.660154,-100.167181, Matan a joven de dos balazos ,1,0,0,0,0
+2011, 1 de Noviembre  ,25.694883,-100.192417, Dejan camioneta con dos asesinados ,0,0,0,0,0
+2011, 23 de Noviembre  ,25.745679,-100.163323, Muere poli tras abatir a dos ex compa&#241;eros ,0,0,0,0,0
+2011, 13 de Noviembre  ,25.71335,-100.183296, Acribillan a una familia; matan a tres ,0,0,0,0,0
+2011, 11 de Noviembre  ,25.772548,-100.264569, Localizan federales camioneta robada ,0,0,0,0,0
+2011, 10 de Noviembre  ,25.767084,-100.195616, Ejecutan pistoleros a 3 frente a dep&#243;sito ,0,0,0,0,0
+2011, 23 de Noviembre  ,25.806382,-100.27977, Balean a fiscal federal; se refugia en PGR ,0,0,0,0,0
+2011, 16 de Noviembre  ,25.762171,-100.238916, Asesinan a hombre y lo tiran ,0,0,0,0,0
+2011, 13 de Noviembre  ,25.784351,-100.260704, Ejecutan a uno plagian a otro ,0,0,0,0,0
+2011, 10 de Noviembre  ,25.762171,-100.238916, Decomisan $2 millones a narcoc&#233;lula ,0,0,0,0,0
+2011, 9 de Noviembre  ,24.822924,-100.074472, Hallan narcococina en Galeana ,0,0,0,0,0
+2011, 27 de Noviembre  ,25.788917,-100.597801, Lo bajan de veh&#237;culo y lo matan a balazos ,0,0,0,0,0
+2011, 5 de Noviembre  ,25.771837,-100.472374, Lo matan de 2 tiros ,1,0,0,0,0
+2011, 6 de Noviembre  ,25.4549,-100.165443, Matan pistoleros a un comerciante ,1,0,0,0,0
+2011, 19 de Noviembre  ,25.267857,-100.005336, Lo ejecutan de 6 balazos ,0,0,0,0,0
+2011, 4 de Noviembre  ,25.187078,-99.798775, Se niega a pagar cuota y lo ejecutan ,1,0,0,0,0
+2011, 9 de Noviembre  ,25.25382,-99.678077, Decapitan a hombre y le prenden fuego ,0,0,0,0,0
+2011, 6 de Noviembre  ,25.73187,-99.213409, Mutilan cuerpo ,1,0,0,0,0
+2011, 16 de Noviembre  ,25.562148,-99.981441, Los acribillan en Cadereyta ,0,0,0,0,0
+2011, 12 de Noviembre  ,25.559787,-100.065022, Sepultan en narcofosa a 2 plagiados ,2,0,2,0,0
+2011, 9 de Noviembre  ,25.576833,-100.00934, Levantan a menor y luego lo ejecutan ,0,0,0,0,0
+2011, 1 de Noviembre  ,25.593517,-99.990181, Le dan el tiro de gracia a mujer ,0,0,0,0,0
+2011, 28 de Noviembre  ,26.08427,-99.615601, Hallan militares un narcorrancho en Cerralvo ,0,0,0,0,0
+2011, 30 de Octubre    ,25.657949,-100.412228, Dejan en San Pedro a pareja ejecutada ,2,0,0,0,0
+2011, 29 de Octubre    ,25.659734,-100.369704, Encuentran a 2 ejecutados en cerro ,0,0,0,0,0
+2011, 5 de Octubre    ,25.656156,-100.17411, Someten a 3 y los ejecutan ,0,0,0,0,0
+2011, 30 de Octubre    ,25.682936,-100.334723, Lo matan a balazos en la Mar&#237;a Luisa ,1,0,0,0,0
+2011, 29 de Octubre    ,25.748219,-100.352802, Levantan a mujer; aparece decapitada ,0,0,0,0,0
+2011, 27 de Octubre    ,25.6847,-100.291565, Y fallece otro baleado ,0,0,0,0,0
+2011, 22 de Octubre    ,25.63003,-100.294019, Ejecutan a taxista tras persecuci&#243;n ,0,0,0,0,0
+2011, 19 de Octubre    ,25.679068,-100.316827, Impiden levant&#243;n polic&#237;as en Centro ,0,0,0,0,0
+2011, 19 de Octubre    ,25.785461,-100.413103, Ejecutan a hombre al salir de su casa ,0,0,0,0,0
+2011, 19 de Octubre    ,25.75397,-100.376459, Lo persiguen para matarlo de 7 disparos ,0,0,0,0,0
+2011, 6 de Octubre    ,25.685007,-100.260678, Cazan y matan a hombre de 3 balazos en la cabeza ,0,0,0,0,0
+2011, 6 de Octubre    ,25.63031,-100.273499, Impide Ej&#233;rcito ataque a familia ,0,0,0,0,0
+2011, 5 de Octubre    ,25.746803,-100.354, Persiguen a un taxista le dan cerr&#243;n y lo matan ,0,0,0,0,0
+2011, 5 de Octubre    ,25.678037,-100.313307, Cae muerto a balazos repartidor de frituras ,0,0,0,0,0
+2011, 3 de Octubre    ,25.717352,-100.354636, Desatan balacera en Lincoln ,0,0,2,0,0
+2011, 3 de Octubre    ,25.76032,-100.370235, Ejecutan a hombre de nueve balazos ,1,0,0,0,0
+2011, 2 de Octubre    ,25.642484,-100.299382, Matan a mujer y a sus 2 hijos ,4,0,0,0,0
+2011, 2 de Octubre    ,25.727501,-100.348692, La acribillan desde autos en marcha ,1,0,0,0,0
+2011, 30 de Octubre    ,25.694883,-100.192417, Dejan un cuerpo frente a negocio ,1,0,0,0,0
+2011, 27 de Octubre    ,25.694883,-100.192417, Lo encuentran amarrado y muerto con un disparo ,0,0,0,0,0
+2011, 1 de Octubre    ,25.637774,-100.199744, Encuentran a un hombre ejecutado en Guadalupe ,0,0,0,0,0
+2011, 23 de Octubre    ,25.740838,-100.174971, Ejecutan a 3 en camioneta estacionada ,3,0,0,0,0
+2011, 6 de Octubre    ,25.767084,-100.195616, Lo ejecutan en la sala de su casa ,0,0,0,0,0
+2011, 27 de Octubre    ,25.792535,-100.303617, Muere hombre al ser torturado ,0,0,0,0,0
+2011, 19 de Octubre    ,25.795956,-100.290162, Atacan pistoleros un bar y dejan a seis lesionados ,0,0,0,0,0
+2011, 22 de Octubre    ,25.426964,-100.151683, Lo asesinan de tres balazos ,0,0,0,0,0
+2011, 16 de Octubre    ,25.180088,-99.83448, Ejecutan a dos frente a su casa ,2,0,0,0,0
+2011, 16 de Octubre    ,25.18568,-99.83036, Lo matan de un balazo en la cabeza ,1,0,0,0,0
+2011, 30 de Octubre    ,25.594123,-99.990435, Tiran cuatro asesinados en Cadereyta ,4,0,0,0,0
+2011, 10 de Octubre    ,25.600664,-99.998245, Matan en Penal de Cadereyta a secuestrador ,1,0,0,0,0
+2011, 23 de Octubre    ,25.848101,-99.9646, Caen pistoleros al cocinar a 4 ,1,0,3,0,0
+2011, 19 de Octubre    ,26.659711,-99.986935, Hallan narcococina en Vallecillo ,0,0,0,0,0
+2011, 16 de Octubre    ,26.65605,-99.983826, Abaten en Vallecillo a 9 en campamento ,0,0,0,0,0
+2011, 6 de Octubre    ,26.659711,-99.986935, Emboscan a federales ,0,0,0,0,0
+2011, 8 de Octubre    ,26.549376,-100.126734, Abate Ej&#233;rcito a 4 en narcorrancho ,4,0,0,0, Drogas Armas Vehículos 
+2011, 15 de Septiembre ,25.635626,-100.18552, Acribillan a 2 en Ju&#225;rez ,0,0,0,0,0
+2011, 29 de Septiembre ,25.701272,-100.300687, Atacan a halc&#243;n; lo matan a tiros ,0,0,0,0,0
+2011, 13 de Septiembre ,25.760474,-100.318308, Matan y queman a una adolescente ,1,0,0,0,0
+2011, 11 de Septiembre ,25.695756,-100.264921, Va de polic&#237;a a narcojefa en San Nicol&#225;s ,0,0,0,0,0
+2011, 30 de Septiembre ,25.645938,-100.286305, Ejecutan a otros 10 en 7 ataques ,0,0,0,0,0
+2011, 30 de Septiembre ,25.777767,-100.370844, Ejecutan a otros 10 en 7 ataques ,0,0,0,0,0
+2011, 30 de Septiembre ,25.669322,-100.271355, Ejecutan a otros 10 en 7 ataques ,0,0,0,0,0
+2011, 30 de Septiembre ,25.657929,-100.320625, Ejecutan a otros 10 en 7 ataques ,0,0,0,0,0
+2011, 28 de Septiembre ,25.65872,-100.317516, Acribillan a 3 j&#243;venes en la Independencia ,0,0,0,0,0
+2011, 25 de Septiembre ,25.587607,-100.253858, Muere en enfrentamiento ,0,0,0,0,0
+2011, 23 de Septiembre ,25.690977,-100.301032, Descuartizan y tiran a mam&#225; y a su hija ,0,0,0,0,0
+2011, 22 de Septiembre ,25.635662,-100.293724, Lo dejan correr y lo matan ,0,0,0,0,0
+2011, 21 de Septiembre ,25.75397,-100.376459, Atacan cuarteles; hieren a polic&#237;as ,0,0,0,0,0
+2011, 19 de Septiembre ,25.58464,-100.256767, Intentan plagiar a hermano de Diputada ,0,0,0,0,0
+2011, 19 de Septiembre ,25.617938,-100.267426, Alarma tiroteo en la zona sur ,0,0,0,0,0
+2011, 17 de Septiembre ,25.673211,-100.309201, Balean a 3 y dan levant&#243;n a 2 en Valle Verde ,0,0,0,0,0
+2011, 17 de Septiembre ,25.682549,-100.353413, Detectan pistola en jardinera de Galer&#237;as ,0,0,0,0,0
+2011, 16 de Septiembre ,25.67,-100.308913, Escapa herido de balacera ,0,0,0,0,0
+2011, 15 de Septiembre ,25.662287,-100.27754, Ejecutan a un halc&#243;n en la puerta de pante&#243;n ,0,0,0,0,0
+2011, 14 de Septiembre ,25.743356,-100.341509, Reactivan terror y ejecutan a 19 ,0,0,0,0,0
+2011, 14 de Septiembre ,25.700504,-100.351392, Hieren a mujer en granadazo a la Ministerial ,0,0,0,0,0
+2011, 14 de Septiembre ,25.594847,-100.263868, Se enfrentan a balazos delincuentes y agentes ,0,0,0,0,0
+2011, 14 de Septiembre ,25.682559,-100.350468, Matan a padres de poli implicado en el Royale ,0,0,0,0,0
+2011, 14 de Septiembre ,25.743823,-100.38032, Ejecuta comando a seis entre ellos a un menor  ,0,0,0,0,0
+2011, 14 de Septiembre ,25.717895,-100.261847, Ejecuta comando a seis entre ellos a un menor  ,0,0,0,0,0
+2011, 12 de Septiembre ,25.679447,-100.344878, Cae por secuestrar al Vaquero Gal&#225;ctico ,0,0,0,0,0
+2011, 12 de Septiembre ,25.786792,-100.393968, Levanta y libera comando a padre e hijo ,0,0,0,0,0
+2011, 11 de Septiembre ,25.649859,-100.308397, Tiran en el sur a descuartizado ,1,0,0,0,0
+2011, 9 de Septiembre ,25.656152,-100.232111, Y detienen a una esp&#237;a en C&#233;ntrika ,0,0,0,0,0
+2011, 8 de Septiembre ,25.678037,-100.313307, Desatan p&#225;nico en Centro regio ,0,0,0,0,0
+2011, 7 de Septiembre ,25.578192,-100.248752, Matan en doble ejecuci&#243;n tambi&#233;n a una inocente ,0,0,0,0,0
+2011, 5 de Septiembre ,25.676689,-100.29685, Lo matan sicarios frente a vecinos ,1,0,0,0,0
+2011, 4 de Septiembre ,25.678037,-100.313307, Atacan a tiros una discoteca en el Barrio ,0,0,0,0,0
+2011, 3 de Septiembre ,25.684091,-100.284362, Detienen a 3 de una c&#233;lula de El Chihuas ,0,0,0,0,0
+2011, 1 de Septiembre ,25.700886,-100.351895, Evade mujer a sicarios al llegar a la Ministerial ,0,0,0,0,0
+2011, 19 de Septiembre ,25.788724,-100.041933, Entierran a 2 tras ejecutarlos ,2,0,0,0,0
+2011, 22 de Septiembre ,25.695857,-100.211304, Ejecutan a oficial y luego a 6 j&#243;venes ,0,0,0,0,0
+2011, 22 de Septiembre ,25.726838,-100.192038, Cae con droga y auto robado tras una persecuci&#243;n ,0,0,0,0,0
+2011, 14 de Septiembre ,25.717666,-100.197643, Matan a 2 dentro de su casa ,0,0,0,0,0
+2011, 7 de Septiembre ,25.653037,-100.263518, Acribillan a dos en lote de autos ,0,0,0,0,0
+2011, 7 de Septiembre ,25.617909,-100.144522, Capturan a 3 bien armados en Guadalupe ,0,0,0,0,0
+2011, 24 de Septiembre ,25.781562,-100.187597, Encuentran a asesinado en brecha de Apodaca ,0,0,0,0,0
+2011, 24 de Septiembre ,25.743128,-100.189237, Ejecutan a taxista al llegar a su casa ,0,0,0,0,0
+2011, 18 de Septiembre ,25.729296,-100.157021, Tiran cuerpo desde un veh&#237;culo ,0,0,0,0,0
+2011, 15 de Septiembre ,25.760505,-100.208996, Ejecuta comando a tres tr&#225;nsitos ,0,0,0,0,0
+2011, 9 de Septiembre ,25.714177,-100.243863, Caen 3 halcones con narcon&#243;mina ,0,0,0,0, Vehículos Dinero 
+2011, 1 de Septiembre ,25.800012,-100.239402, Abaten a hombre dentro de su casa ,0,0,0,0,0
+2011, 25 de Septiembre ,25.745786,-100.3232, Lo matan de seis tiros ,1,0,0,0,0
+2011, 25 de Septiembre ,25.797805,-100.375643, Ejecutan a taqueros ,2,0,0,0,0
+2011, 23 de Septiembre ,25.792535,-100.303617, La siguen y la atacan a balazos ,0,0,0,0,0
+2011, 10 de Septiembre ,25.778293,-100.289655, Encuentran a asesinado en brecha de Escobedo ,0,0,0,0,0
+2011, 21 de Septiembre ,25.955113,-100.163749, Abaten militares a cinco pistoleros ,0,0,0,0,0
+2011, 13 de Septiembre ,25.936697,-100.362373, Le dan 2 balazos en la cabeza ,0,0,0,0,0
+2011, 17 de Septiembre ,20.449654,-101.539851, Muere en tiroteo; 2 son ejecutados ,0,0,0,0,0
+2011, 24 de Septiembre ,24.85787,-99.566328, Hallan cuerpo en Linares ,0,0,0,0,0
+2011, 8 de Septiembre ,24.85787,-99.566328, Se da balazo pero aun as&#237; lo levantan ,0,0,0,0,0
+2011, 30 de Septiembre ,24.822924,-100.074472, Ejecutan a otros 10 en 7 ataques ,0,0,0,0,0
+2011, 4 de Septiembre ,25.785807,-100.433726, Amarran a guardias en intento de secuestro ,0,0,0,0,0
+2011, 30 de Septiembre ,25.911424,-100.228615, Choque balazos y muerte ,0,0,0,0,0
+2011, 25 de Septiembre ,25.811945,-100.59803, Tiran muerta a mujer ,1,0,0,0,0
+2011, 13 de Septiembre ,25.694682,-100.44352, Cae ex polic&#237;a s&#250;per armado en S. Catarina ,0,0,2,0, Armas Vehículos Dinero 
+2011, 30 de Septiembre ,25.426964,-100.151683, Cae banda en Santiago por muertes y plagios ,0,0,0,0,0
+2011, 23 de Septiembre ,25.399655,-100.128178, Defiende a su hijo y la asesinan ,0,0,0,0,0
+2011, 21 de Septiembre ,25.406494,-100.161538, Decapitan a una mujer en Santiago ,0,0,0,0,0
+2011, 13 de Septiembre ,25.470119,-100.189937, Encuentran muerta a tiros a una pareja en El Barrial ,2,0,0,0,0
+2011, 12 de Septiembre ,25.449889,-100.163683, Matan a pareja dentro de auto en Santiago ,2,0,0,0,0
+2011, 7 de Septiembre ,25.426964,-100.151683, Matan a ex reo en Santiago ,0,0,0,0,0
+2011, 30 de Septiembre ,25.593517,-99.990181, Ejecutan a otros 10 en 7 ataques ,0,0,0,0,0
+2011, 10 de Septiembre ,25.593517,-99.990181, Busca a hermano; lo halla ejecutado ,0,0,0,0,0
+2011, 4 de Septiembre ,25.590519,-99.982151, Mueren 4 sicarios en enfrentamiento ,0,0,0,0,0
+2011, 3 de Septiembre ,25.698735,-99.624754, Ejecutan a dos en Los Ramones ,0,0,0,0,0
+2011, 22 de Agosto     ,25.634897,-100.08095, Lo dejan en un bald&#237;o tras matarlo ,1,0,0,0,0
+2011, 21 de Agosto     ,25.619704,-100.173855, Dejan un cuerpo frente a vivienda ,0,0,0,0,0
+2011, 15 de Agosto     ,25.739118,-100.296142, Tiran puerta para levantar a joven ,0,0,0,0,0
+2011, 12 de Agosto     ,25.726445,-100.240366, Abre mujer puerta y sicarios la matan ,0,0,0,0,0
+2011, 10 de Agosto     ,25.738467,-100.407831, Atrapa Marina a l&#237;der Zeta de San Nicol&#225;s ,0,0,0,0,0
+2011, 9 de Agosto     ,25.713983,-100.214633, Reportan vecinos balazos; encuentran a 3 ejecutado ,0,0,0,0,0
+2011, 6 de Agosto     ,25.712229,-100.281572, Ejecutan a 5 j&#243;venes ,5,0,0,0,0
+2011, 2 de Agosto     ,25.755566,-100.276937, Balean a oficiales nicola&#237;tas ,0,2,0,0,0
+2011, 31 de Agosto     ,25.738467,-100.407831, Tiran muerto en un parque de Cumbres ,0,0,0,0,0
+2011, 30 de Agosto     ,25.727385,-100.427055, Detectan &quot;narcococina&quot; ,3,0,0,0,0
+2011, 28 de Agosto     ,25.649859,-100.308397, Tiran atado un cad&#225;ver ,0,0,0,0,0
+2011, 25 de Agosto     ,25.674175,-100.318437, Y ejecutan en Av. Ju&#225;rez ,0,0,0,0,0
+2011, 25 de Agosto     ,25.688887,-100.371409, Calcinan a inocentes ,0,0,0,0,0
+2011, 24 de Agosto     ,25.733982,-100.32874, Capturan en hotel a seis con arsenal ,0,0,0,0,0
+2011, 24 de Agosto     ,25.698946,-100.286656, Sospechan que plagiados matan a su secuestrador ,0,0,0,0,0
+2011, 23 de Agosto     ,25.670308,-100.346031, Cuelgan a uno en Constituci&#243;n a pleno mediod&#237;a ,0,0,0,0,0
+2011, 23 de Agosto     ,25.71475,-100.342071, Matan a otro en auto ,0,0,0,0,0
+2011, 23 de Agosto     ,25.746803,-100.354, Baja sicario de taxi y asesina a joven ,0,0,0,0,0
+2011, 23 de Agosto     ,25.657192,-100.311994, Ejecutan a uno atr&#225;s de la Central ,0,0,0,0,0
+2011, 22 de Agosto     ,25.629087,-100.299132, Balean a 5 j&#243;venes al rafaguear auto ,2,3,0,0,0
+2011, 21 de Agosto     ,25.650579,-100.307772, Hallan cuerpo en bolsas ,0,0,0,0,0
+2011, 20 de Agosto     ,25.670849,-100.285006, Bloquean disparan y colocan narcomantas en puentes ,0,0,0,0,0
+2011, 19 de Agosto     ,25.649859,-100.308397, Dejan en tres bolsas cuerpo descuartizado ,0,0,0,0,0
+2011, 17 de Agosto     ,25.659864,-100.276594, Lo bajan de auto y le dan 8 tiros ,1,0,0,0,0
+2011, 16 de Agosto     ,25.679087,-100.308437, Ejecutan en Tapia a un polic&#237;a regio ,1,0,0,0,0
+2011, 14 de Agosto     ,25.686881,-100.325432, Torturan a 2 y los deg&#252;ellan ,0,0,0,0,0
+2011, 13 de Agosto     ,25.706847,-100.314452, Muere inocente por bala perdida ,0,0,0,0,0
+2011, 11 de Agosto     ,25.649859,-100.308397, Hallan 2 cuerpos con tiro de gracia ,0,0,0,0,0
+2011, 10 de Agosto     ,25.704413,-100.281747, Ejecutan a hombre y lesionan a otro ,0,0,0,0,0
+2011, 10 de Agosto     ,25.748219,-100.352802, Mata comando a comerciante de refacciones ,0,0,0,0,0
+2011, 9 de Agosto     ,25.723111,-100.336489, Entran pistoleros a Penal del Topo; mueren 2 a tiros ,0,0,0,0,0
+2011, 9 de Agosto     ,25.691028,-100.356807, Plagian a mujer en Vista Hermosa ,0,0,0,0,0
+2011, 9 de Agosto     ,25.698946,-100.286656, Tiran a un mutilado ,1,0,0,0,0
+2011, 8 de Agosto     ,25.666459,-100.297709, Cuelgan a joven de Puente F&#233;lix U. G&#243;mez ,1,0,0,0,0
+2011, 7 de Agosto     ,25.68369,-100.2917, Esposan a mujer y la matan a tiros ,1,0,0,0,0
+2011, 7 de Agosto     ,25.681872,-100.302815, Lo acribillan de 15 balazos en el Centro ,1,0,0,0,0
+2011, 5 de Agosto     ,25.663452,-100.281747, Tiran a mujer decapitada en Revoluci&#243;n ,1,0,0,0,0
+2011, 4 de Agosto     ,25.725007,-100.342877, Atacan Penal y lesionan a 4 inocentes ,0,6,0,0,0
+2011, 3 de Agosto     ,25.688447,-100.294318, Lo mata comando en un auto robado ,1,0,0,0,0
+2011, 2 de Agosto     ,25.65379,-100.303631, Ejecutan a hombre ,1,0,0,0,0
+2011, 1 de Agosto     ,25.686242,-100.30715, Lo matan pistoleros en la Col. Trevi&#241;o ,1,0,0,0,0
+2011, 1 de Agosto     ,25.63255,-100.285478, Rescata Ej&#233;rcito a 5 secuestrados ,0,0,3,0, Vehículos 
+2011, 1 de Agosto     ,25.661875,-100.30494, Ejecutan a pareja dentro de un auto ,2,0,0,0, Vehículos 
+2011, 23 de Agosto     ,25.785,-100.051111, Dejan muerta entre hierba a una mujer ,0,0,0,0,0
+2011, 14 de Agosto     ,25.785,-100.051111, Hallan encobijado en brecha ,0,0,0,0,0
+2011, 25 de Agosto     ,25.694883,-100.192417, Matan a balazos a un ex tr&#225;nsito de San Nicol&#225;s ,0,0,0,0,0
+2011, 23 de Agosto     ,25.719862,-100.193256, Se esconde en tienda; lo hallan y lo asesinan ,0,0,0,0,0
+2011, 21 de Agosto     ,25.649883,-100.199261, Abaten a asaltante en enfrentamiento ,0,0,0,0,0
+2011, 13 de Agosto     ,22.758368,-102.495158, Caen 3 por distribuir coca&#237;na en un taxi ,0,0,0,0,0
+2011, 12 de Agosto     ,25.669447,-100.137511, Ejecutan a 4 en una hora ,0,0,0,0,0
+2011, 11 de Agosto     ,25.643188,-100.200795, Encuentran a un asesinado en Guadalupe ,0,0,0,0,0
+2011, 3 de Agosto     ,25.677772,-100.231533, Encuentran 2 ejecutados en auto de lujo ,2,0,0,0, Vehículos 
+2011, 2 de Agosto     ,25.672164,-100.204968, Encuentran en Guadalupe un decapitado ,1,0,0,0,0
+2011, 1 de Agosto     ,25.665724,-100.270178, Asesinan a dos hombres desde un auto ,2,0,0,0,0
+2011, 26 de Agosto     ,25.754939,-100.237164, Hallan cad&#225;ver de hombre encintado ,0,0,0,0,0
+2011, 24 de Agosto     ,25.767084,-100.195616, Ejecutan a cinco hombres que desmantelaban un auto ,0,0,0,0,0
+2011, 12 de Agosto     ,25.740986,-100.183283, Balean en persecuci&#243;n a inocente en Apodaca ,0,0,0,0,0
+2011, 10 de Agosto     ,25.692198,-100.263167, Acribillan sicarios a dos en Apodaca ,0,0,0,0,0
+2011, 3 de Agosto     ,25.775682,-100.185871, Levantan a familia &#161;con ni&#241;os! ,0,0,0,0,0
+2011, 1 de Agosto     ,25.761499,-100.253227, Acribillan a 2 en Apodaca ,2,0,0,0,0
+2011, 20 de Agosto     ,25.779174,-100.316827, Muere 1 en tiroteo; inocente sale herido ,0,0,0,0,0
+2011, 12 de Agosto     ,25.803929,-100.352596, Libera Ej&#233;rcito a secuestrado y detiene a 11 ,0,0,0,0,0
+2011, 13 de Agosto     ,25.674297,-100.437074, Tiran en Santa Catarina a un hombre encobijado ,0,0,0,0,0
+2011, 2 de Agosto     ,25.684463,-100.504775, Aseguran en casa $6.5 millones del narco ,0,0,0,0, Drogas Armas Dinero 
+2011, 28 de Agosto     ,25.427617,-100.147934, Ejecutan a dos al rafaguear bar ,2,0,0,0,0
+2011, 22 de Agosto     ,25.533458,-100.216169, Tiran a 2 descuartizados en Santiago ,2,0,0,0,0
+2011, 20 de Agosto     ,25.517226,-100.220733, Lo ejecutan frente a su padre ,0,0,0,0,0
+2011, 17 de Agosto     ,25.486012,-100.174799, Hallan a ejecutado en brecha de Santiago ,1,0,0,0,0
+2011, 13 de Agosto     ,25.283611,-100.020278, Lo asesinan en Allende ,0,0,0,0,0
+2011, 10 de Agosto     ,25.283611,-100.020278, Explota artefacto en Allende frente a la antigua Presidencia ,0,0,0,0,0
+2011, 9 de Agosto     ,25.283611,-100.020278, Dejan a ejecutado afuera de pante&#243;n ,0,0,0,0,0
+2011, 4 de Agosto     ,25.275513,-100.018845, Cobra revancha macabra c&#225;rtel rival ,2,0,0,0,0
+2011, 1 de Agosto     ,25.305933,-99.999704, Matan y mutilan a sobrina de Secretaria ,2,0,0,0,0
+2011, 20 de Agosto     ,25.183496,-99.829679, Torturan y matan a socorrista e hijo ,0,0,0,0,0
+2011, 14 de Agosto     ,25.183496,-99.829679, Ejecutan a mujer de un balazo en la cabeza ,0,0,0,0,0
+2011, 5 de Agosto     ,25.183496,-99.829679, Peligran 3 agentes tras ataque a tiros ,0,0,0,0,0
+2011, 29 de Agosto     ,25.25382,-99.678077, Ejecutan a mujer y la entamban ,1,0,0,0,0
+2011, 9 de Agosto     ,25.25382,-99.678077, Hallan a hombre descuartizado en Ter&#225;n ,0,0,0,0,0
+2011, 10 de Agosto     ,25.701557,-99.238129, Ejecutan a parejas en la Autopista ,0,0,0,0,0
+2011, 31 de Agosto     ,25.593517,-99.990181, Mueren 5 sicarios en enfrentamiento ,0,0,0,0,0
+2011, 25 de Agosto     ,25.593517,-99.990181, Creen que abaten a l&#237;der descuartizador ,0,0,0,0,0
+2011, 15 de Agosto     ,25.60763,-99.958763, Hallan a ejecutado dentro de tambo ,1,0,0,0,0
+2011, 2 de Agosto     ,25.521453,-100.008717, Descuartizan a una mujer ,1,0,0,0,0
+2011, 1 de Agosto     ,25.534697,-100.008888, Descuartizan a un tatuado en Cadereyta ,1,0,0,0,0
+2011, 18 de Agosto     ,26.258936,-99.763756, Abaten militares a 10 ,10,0,0,0,0
+2011, 25 de Julio      ,25.867874,-100.04425, Prenden enfrentamientos la zona rural (Mar&#237;n) ,0,0,0,0,0
+2011, 21 de Julio      ,25.65878,-100.367446, Ahora ejecutan en Centrito Valle ,1,1,0,0,0
+2011, 20 de Julio      ,25.657233,-100.36972, Estrenan a mandos; ejecutan a tr&#225;nsito ,1,0,0,0,0
+2011, 25 de Julio      ,25.645859,-100.103989, Dejan a hombre muerto a golpes ,1,0,0,0,0
+2011, 24 de Julio      ,25.617072,-100.178146, Detienen a plagiario; liberan a secuestrados ,0,0,1,0,0
+2011, 13 de Julio      ,25.64716,-100.138817, Matan a mujer y la entierran en un bald&#237;o ,0,0,0,0,0
+2011, 30 de Julio      ,25.728941,-100.309689, Asesinan a 4 en San Nicol&#225;s ,0,0,0,0,0
+2011, 18 de Julio      ,25.748376,-100.276122, Matan a balazos a pareja en San Nicol&#225;s ,2,0,0,0,0
+2011, 6 de Julio      ,25.747883,-100.253559, Dan un levant&#243;n a mando nicola&#237;ta ,0,0,0,0,0
+2011, 5 de Julio      ,25.745361,-100.31142, Acribillan a 2 polis nicola&#237;tas ,2,0,0,0,0
+2011, 31 de Julio      ,25.736173,-100.356196, Ejecutan a dos y los encajuelan ,0,0,0,0,0
+2011, 30 de Julio      ,25.577682,-100.243731, Dejan en bolsas cuerpo decapitado ,0,0,0,0,0
+2011, 25 de Julio      ,25.782355,-100.408754, Muere a tiros tras evitar ser levantada ,1,0,0,0,0
+2011, 25 de Julio      ,25.63758,-100.299489, Lo bajan de auto y lo asesinan ,1,0,0,0,0
+2011, 24 de Julio      ,25.644273,-100.306528, Rafaguean a tres; uno muere ,1,2,0,0,0
+2011, 19 de Julio      ,25.616132,-100.270704, Dejan a un ejecutado mensaje de secuestrador ,0,0,0,0,0
+2011, 18 de Julio      ,25.629339,-100.2755, Ejecutan comandos a dos polic&#237;as ,4,0,0,0,0
+2011, 18 de Julio      ,25.493953,-100.187502, Tiran tres cabezas en El Yerbaniz ,3,0,0,0,0
+2011, 17 de Julio      ,25.656711,-100.325303, Decapitan a dos en la zona sur ,2,0,0,0,0
+2011, 17 de Julio      ,25.728622,-100.371244, Tiran a asesinado dentro de empresa ,1,0,0,0,0
+2011, 16 de Julio      ,25.721921,-100.364527, Detienen a 8 tras rescatar a un plagiado ,0,0,0,0,0
+2011, 15 de Julio      ,25.61655,-100.293632, Caen 4 sicarios; les hallan arsenal ,0,0,4,0, Armas Vehículos 
+2011, 14 de Julio      ,25.758414,-100.286885, Tiran a 2 descuartizados frente a escuela primaria ,0,0,0,0,0
+2011, 13 de Julio      ,25.65872,-100.317516, Caen 3 por ataque a tiros contra polic&#237;as estatales ,0,0,0,0,0
+2011, 13 de Julio      ,25.748056,-100.383015, Abate Ej&#233;rcito a 9 en doble balacera ,0,0,0,0,0
+2011, 13 de Julio      ,25.751771,-100.356105, Asesinan a balazos a otro en Colonia Francisco Villa ,0,0,0,0,0
+2011, 13 de Julio      ,25.506503,-100.193081, Ejecutan a 2 hombres en la Carretera Nacional ,0,0,0,0,0
+2011, 13 de Julio      ,28.694238,-100.538076, Tiran en Avenida Leones a hombre descuartizado ,0,0,0,0,0
+2011, 12 de Julio      ,25.65872,-100.317516, Deja 19 muertos racha de 21 horas ,0,0,0,0,0
+2011, 12 de Julio      ,25.727849,-100.373652, Deja 19 muertos racha de 21 horas ,0,0,0,0,0
+2011, 12 de Julio      ,25.751771,-100.356105, Deja 19 muertos racha de 21 horas ,0,0,0,0,0
+2011, 10 de Julio      ,25.689474,-100.376271, Hallan a ejecutado en San Jer&#243;nimo ,1,0,0,0,0
+2011, 9 de Julio      ,25.748219,-100.352802, Pelean pistoleros; matan a inocente ,0,0,0,0,0
+2011, 8 de Julio      ,25.682403,-100.275064, Masacran a 20 en ataque a bar ,0,0,0,0,0
+2011, 8 de Julio      ,25.549624,-100.224292, Tiran en El Uro a un encobijado ,0,0,0,0,0
+2011, 7 de Julio      ,25.629058,-100.273172, Acribillan a 2 en Contry dentro de auto ,2,0,0,0,0
+2011, 1 de Julio      ,25.686959,-100.280345, Lanzan otro ataque a un bar del Centro. ,0,0,0,0,0
+2011, 16 de Julio      ,25.785,-100.051111, Envuelven en narcomanta a un hombre asesinado ,0,0,0,0,0
+2011, 9 de Julio      ,25.785,-100.051111, Hallan m&#225;s restos humanos en Pesquer&#237;a ,0,0,0,0,0
+2011, 8 de Julio      ,25.785,-100.051111, Encuentran 3 calcinados ,0,0,0,0,0
+2011, 27 de Julio      ,25.661333,-100.258484, Salvan a polic&#237;as chalecos antibalas ,0,0,0,0,0
+2011, 27 de Julio      ,25.74022,-100.128365, Tiran dos ejecutados en autopista ,0,0,0,0,0
+2011, 27 de Julio      ,25.648208,-100.207451, Abaten en tiroteo a tres pistoleros ,0,0,0,0,0
+2011, 26 de Julio      ,25.668683,-100.29273, Encuentran a un calcinado en el R&#237;o Santa Catarina ,0,0,0,0,0
+2011, 26 de Julio      ,25.763103,-100.127678, Lo tiran envuelto en narcomanta ,0,0,0,0,0
+2011, 12 de Julio      ,25.684139,-100.250999, Deja 19 muertos racha de 21 horas ,0,0,0,0,0
+2011, 8 de Julio      ,25.616864,-100.261543, Desatan balacera polic&#237;as y narcos en zona Contry ,0,0,0,0,0
+2011, 3 de Julio      ,25.660308,-100.23222, Mueren 2 sicarios al enfrentar a polis ,2,2,0,0, Armas Vehículos 
+2011, 1 de Julio      ,25.684139,-100.250999, Cae banda de secuestradores expr&#233;s ,0,0,0,0,0
+2011, 14 de Julio      ,25.792876,-100.177388, Abate el Ej&#233;rcito a cuatro sicarios ,0,0,0,0,0
+2011, 12 de Julio      ,25.762257,-100.166824, Deja 19 muertos racha de 21 horas ,0,0,0,0,0
+2011, 30 de Julio      ,25.79261,-100.304215, Torturan y matan en brecha ,0,0,0,0,0
+2011, 27 de Julio      ,25.761866,-100.304146, Atacan a Clara Luz ,0,0,0,0,0
+2011, 13 de Julio      ,25.803929,-100.352596, Hallan a ejecutado sin piel en el rostro ,0,0,0,0,0
+2011, 12 de Julio      ,25.780747,-100.408999, Deja 19 muertos racha de 21 horas ,0,0,0,0,0
+2011, 30 de Julio      ,25.936697,-100.362373, Hallan a narcos un campo de tiro ,0,0,0,0,0
+2011, 25 de Julio      ,25.672164,-100.687981, Hallan a mujer calcinada en Garc&#237;a ,1,0,0,0,0
+2011, 25 de Julio      ,25.808921,-100.597923, Rescatan a mujer; detienen a 5 ,0,0,5,0,0
+2011, 31 de Julio      ,25.698154,-100.468125, Muere hombre calcinado en camioneta ,1,0,0,0,0
+2011, 25 de Julio      ,25.699356,-100.434545, Ejecutan a tres en Santa Catarina ,3,0,0,0,0
+2011, 12 de Julio      ,25.687018,-100.454555, Deja 19 muertos racha de 21 horas ,0,0,0,0,0
+2011, 1 de Julio      ,25.668332,-100.454057, Desatan tiroteo frente a Alcalde ,0,0,0,0,0
+2011, 26 de Julio      ,25.426964,-100.151683, Mueren en enfrentamiento dos pistoleros en Santiago ,0,0,0,0,0
+2011, 25 de Julio      ,25.470119,-100.189937, Lo matan de un disparo en la cabeza ,1,0,0,0,0
+2011, 18 de Julio      ,25.429943,-100.147934, Muere a golpes en Carretera Los Cavazos-Ju&#225;rez ,0,0,0,0,0
+2011, 16 de Julio      ,25.426964,-100.151683, Lo acribillan en una quinta de Santiago ,0,0,0,0,0
+2011, 12 de Julio      ,25.444345,-100.160522, Deja 19 muertos racha de 21 horas ,0,0,0,0,0
+2011, 11 de Julio      ,25.496122,-100.188961, Descuartizan a un hombre ,1,0,0,0,0
+2011, 7 de Julio      ,25.389396,-100.120296, Ejecutan 3 en Santiago ,3,0,0,0,0
+2011, 6 de Julio      ,25.52335,-100.206642, Torturan asesinan y tiran a joven ,1,0,0,0,0
+2011, 3 de Julio      ,25.548327,-100.226383, Hallan a dos descuartizados en bolsas en la Carretera ,1,0,0,0,0
+2011, 25 de Julio      ,25.283611,-100.020278, Asesinan a otros 2 ,0,0,0,0,0
+2011, 16 de Julio      ,25.283611,-100.020278, Tiran muerto en Allende ,0,0,0,0,0
+2011, 13 de Julio      ,25.599937,-99.977086, Lo acribillan en Allende ,0,0,0,0,0
+2011, 25 de Julio      ,25.183496,-99.829679, Encuentran cad&#225;ver tirado en brecha ,1,0,0,0,0
+2011, 6 de Julio      ,25.201213,-99.913273, Dejan enterrado a un ejecutado ,1,0,0,0, Vehículos 
+2011, 6 de Julio      ,25.196631,-99.839716, Acribillan a polic&#237;a de Montemorelos ,1,0,0,0,0
+2011, 13 de Julio      ,25.593517,-99.990181, Abate Ej&#233;rcito a 9 en doble balacera ,0,0,0,0,0
+2011, 12 de Julio      ,25.599425,-99.968376, Deja 19 muertos racha de 21 horas ,0,0,0,0,0
+2011, 12 de Julio      ,25.593517,-99.990181, Deja 19 muertos racha de 21 horas ,0,0,0,0,0
+2011, 31 de Julio      ,26.498844,-100.171967, Ubican en Sabinas otro campo de tiro ,0,0,1,0, Armas Vehículos 
+2011, 25 de Julio      ,26.506905,-100.179453, Prenden enfrentamientos la zona rural (Sabinas) ,5,0,0,0, Armas 
+2011, 18 de Julio      ,26.50376,-100.185699, Prenden fuego a una mujer en autopista ,1,0,0,0,0
+2011, 1 de Julio      ,26.506905,-100.179453, Sorprenden y ejecutan a agentes de inteligencia ,0,0,0,0,0
+2011, 17 de Julio      ,27.236316,-100.123901, Hallan a ejecutado dentro de una noria ,1,0,0,0,0
+2011, 16 de Julio      ,27.232639,-100.134399, Ligan a detenido con carga de coca ,0,0,0,0,0
+2011, 21 de Junio      ,25.674736,-100.402851, Hieren en tiroteo a 3 inocentes ,0,3,0,0,0
+2011, 15 de Junio      ,25.642586,-100.312956, Aterra cifra mortal ,0,0,0,0,0
+2011, 13 de Junio      ,25.636342,-100.374098, Roban Audi y desatan persecuci&#243;n ,0,0,1,0, Vehículos 
+2011, 13 de Junio      ,25.644389,-100.311184, Muere halc&#243;n a balazos en su sitio de vigilancia ,1,0,0,0,0
+2011, 24 de Junio      ,25.548017,-100.121155, Hallan en Ju&#225;rez rancho del terror ,0,0,0,0,0
+2011, 3 de Junio      ,25.647326,-100.094528, Caen sicarios dormidos y les aseguran 7 fusiles ,0,0,4,0, Armas 
+2011, 3 de Junio      ,25.647326,-100.094528, Muere un pistolero al huir de militares ,1,0,0,0,0
+2011, 29 de Junio      ,25.691732,-100.304803, Asesinan a hombre a tiros; despu&#233;s le prenden fuego ,0,0,0,0,0
+2011, 26 de Junio      ,25.711842,-100.281916, Ejecutan sicarios a joven maniatado  ,1,0,0,0,0
+2011, 30 de Junio      ,25.647047,-100.216949, Se resguarda de lluvia y lo asesinan a balazos ,0,0,0,0,0
+2011, 30 de Junio      ,25.549624,-100.224292, Dejan cuerpo bajo puente ,0,0,0,0,0
+2011, 29 de Junio      ,25.691347,-100.280345, Matan a hermanos frente a su mam&#225; ,0,0,0,0,0
+2011, 29 de Junio      ,25.695423,-100.295071, Balean a polic&#237;a cerca del Cuartel ,0,0,0,0,0
+2011, 28 de Junio      ,25.708958,-100.378112, Frena huida de pistoleros laberinto vial ,0,0,0,0,0
+2011, 27 de Junio      ,25.66025,-100.295949, Matan a tiros a 5 y dejan a uno herido ,5,0,0,0,0
+2011, 25 de Junio      ,25.578756,-100.239043, Fusilan a cuatro en La Estanzuela ,4,0,0,0,0
+2011, 23 de Junio      ,25.662919,-100.290112, Ejecutan a 8 en menos de 6 horas ,8,0,0,0,0
+2011, 22 de Junio      ,25.647968,-100.307043, Ejecutan a 3 en 2 ataques en la zona sur ,3,0,0,0,0
+2011, 19 de Junio      ,25.68486,-100.33733, Tiran 2 muertos y los relacionan con balacera ,2,0,0,0,0
+2011, 19 de Junio      ,25.739085,-100.336255, Roban pistoleros cuerpo de un asesinado ,0,0,0,0,0
+2011, 17 de Junio      ,25.710743,-100.346983, Caen halcones a 2 cuadras de la Ministerial ,0,0,0,0,0
+2011, 17 de Junio      ,25.654553,-100.310783, Asesinan sicarios a cinco ,0,0,0,0,0
+2011, 16 de Junio      ,25.580771,-100.237758, Detiene Federal a 4 con armas y granada ,0,0,0,0,0
+2011, 16 de Junio      ,25.686447,-100.297876, Lo decapitan afuera de bar en la Terminal ,0,0,0,0,0
+2011, 15 de Junio      ,25.676402,-100.356807, Aterra cifra mortal ,0,0,0,0,0
+2011, 15 de Junio      ,25.698946,-100.286656, Aterra cifra mortal ,0,0,0,0,0
+2011, 15 de Junio      ,25.678037,-100.313307, Aterra cifra mortal ,0,0,0,0,0
+2011, 15 de Junio      ,25.669322,-100.271355, Aterra cifra mortal ,0,0,0,0,0
+2011, 15 de Junio      ,25.676402,-100.356807, Aterra cifra mortal ,0,0,0,0,0
+2011, 14 de Junio      ,25.714207,-100.370142, Muere poli-militar en una emboscada ,0,0,0,0,0
+2011, 13 de Junio      ,25.738519,-100.332298, Mueren 3 pistoleros en enfrentamiento ,3,1,0,0, Armas Vehículos 
+2011, 13 de Junio      ,25.667136,-100.284147, Ahora cuelgan y queman a uno en puente ,1,0,0,0,0
+2011, 12 de Junio      ,25.691994,-100.274673, Dejan en plaza a un decapitado ,0,0,0,0,0
+2011, 11 de Junio      ,25.616506,-100.278697, Matan sicarios a una pareja; sale ilesa beb&#233; ,0,0,0,0,0
+2011, 11 de Junio      ,25.618404,-100.267023, Hallan a muerto y a 7 plagiados en una minivan ,0,0,0,0,0
+2011, 11 de Junio      ,25.587607,-100.253858, Tiran cuerpo decapitado en zona sur ,0,0,0,0,0
+2011, 10 de Junio      ,25.685058,-100.341849, Pegan granadazo a la Ministerial ,0,0,0,0,0
+2011, 8 de Junio      ,25.667097,-100.284448, Estrena narco modalidad: colgarlos vivos ,2,0,0,0,0
+2011, 8 de Junio      ,25.677076,-100.35234, Tiran cabeza de mujer en Av. Gonzalitos ,1,0,0,0,0
+2011, 5 de Junio      ,25.712422,-100.350173, Cuelgan 2 cuerpos en Gonzalitos ,2,0,0,0,0
+2011, 5 de Junio      ,25.724662,-100.194404, Acribillan a tres al salir de auto ,0,0,0,0,0
+2011, 5 de Junio      ,25.666762,-100.286656, Muere en hospital un polic&#237;a baleado ,1,0,0,0,0
+2011, 4 de Junio      ,25.58495,-100.256596, Hallan a decapitado en La Estanzuela ,1,0,0,0,0
+2011, 3 de Junio      ,25.65872,-100.317516, Destruye Federal granada hallada afuera de capilla ,0,0,0,0,0
+2011, 2 de Junio      ,25.75397,-100.376459, Matan a 2; se roban cuerpos ,0,0,0,0,0
+2011, 1 de Junio      ,25.649859,-100.308397, Dejan a encobijado junto a centro de salud ,0,0,0,0,0
+2011, 1 de Junio      ,25.587607,-100.253858, Matan a otro en La Estanzuela ,0,0,0,0,0
+2011, 15 de Junio      ,25.785,-100.051111, Deja GPS pista: cae un ejecutor ,0,0,0,0,0
+2011, 15 de Junio      ,25.785,-100.051111, Aterra cifra mortal ,0,0,0,0,0
+2011, 28 de Junio      ,25.665048,-100.22548, Ejecuta comando a 3 en una plaza ,0,0,0,0,0
+2011, 20 de Junio      ,25.723171,-100.182953, Matan y queman a tres tr&#225;nsitos ,3,0,0,0,0
+2011, 19 de Junio      ,25.678303,-100.158373, Ejecutan a cuatro en Col. Dos R&#237;os ,4,0,0,0,0
+2011, 15 de Junio      ,25.68831,-100.19379, Aterra cifra mortal ,0,0,0,0,0
+2011, 15 de Junio      ,25.653878,-100.190149, Aterra cifra mortal ,0,0,0,0,0
+2011, 15 de Junio      ,25.664454,-100.26482, Desaf&#237;a narcocrimen seguridad de Medina ,0,0,0,0,0
+2011, 14 de Junio      ,25.668418,-100.21549, Libra atentado coordinador de la Polic&#237;a de Guadalupe ,0,0,0,0,0
+2011, 14 de Junio      ,22.753515,-102.512755, Matan a comerciante e intentan colgarlo ,0,0,0,0,0
+2011, 13 de Junio      ,25.683999,-100.221587, Descuartizan a comandante ,1,1,0,0, Vehículos 
+2011, 5 de Junio      ,25.6828,-100.230503, Dejan a descuartizado frente a Polic&#237;a ,1,0,0,0,0
+2011, 3 de Junio      ,25.686984,-100.209134, Enfrentan polic&#237;as a militares ,0,1,5,0,0
+2011, 16 de Junio      ,25.790612,-100.252709, Acribillan a cuatro en kiosco de plaza ,0,0,0,0,0
+2011, 16 de Junio      ,25.727776,-100.173477, Matan a hombre a balazos luego asesinos lo arrollan ,0,0,0,0,0
+2011, 10 de Junio      ,25.738312,-100.169275, Matan en Apodaca a vendedor de droga ,0,0,0,0,0
+2011, 16 de Junio      ,25.812564,-100.294189, Desatan granadazos contra sedes de PGR y PF ,0,0,0,0,0
+2011, 14 de Junio      ,25.79,-100.281487, Detiene Ej&#233;rcito a capo y sicarios ,0,0,0,0,0
+2011, 11 de Junio      ,25.762171,-100.238916, Abaten federales a tres pistoleros ,0,0,0,0,0
+2011, 1 de Junio      ,25.79261,-100.304215, Ejecuta comando a dos celadores ,0,0,0,0,0
+2011, 7 de Junio      ,24.885502,-99.672432, Tiran 3 cabezas en Hualahuises ,3,0,0,0,0
+2011, 30 de Junio      ,25.808921,-100.597923, Tiran en Garc&#237;a a descuartizado ,0,0,0,0,0
+2011, 29 de Junio      ,25.694443,-100.460169, Cae asesino de General ,0,0,0,0,0
+2011, 15 de Junio      ,25.808921,-100.597923, Aterra cifra mortal ,0,0,0,0,0
+2011, 28 de Junio      ,25.700723,-100.466383, Matan a taquero en S. Catarina ,0,0,0,0,0
+2011, 27 de Junio      ,25.655105,-100.45186, Ejecutan a jefe en sede &#161;de la Polic&#237;a! ,1,0,0,0,0
+2011, 5 de Junio      ,25.671576,-100.424204, Lo matan frente a tienda; se llevan cuerpo ,1,0,0,0,0
+2011, 22 de Junio      ,25.471019,-100.184155, Acribillan a entrenador de caballos ,1,0,0,0,0
+2011, 8 de Junio      ,25.457089,-100.16731, Abaten tras persecuci&#243;n a 1 en Santiago ,1,0,0,0, Vehículos 
+2011, 17 de Junio      ,25.283611,-100.020278, Esposan y ejecutan en brecha de Allende ,0,0,0,0,0
+2011, 6 de Junio      ,25.614596,-100.102959, Hallan 7 cuerpos en narcofosa de Ju&#225;rez ,7,0,0,0,0
+2011, 12 de Junio      ,25.180088,-99.863663, Rafaguean la Polic&#237;a de Montemorelos ,0,0,0,0,0
+2011, 2 de Junio      ,25.183496,-99.829679, Detienen a 5 con armas en una casa de seguridad ,0,0,0,0,0
+2011, 12 de Junio      ,25.237243,-99.684448, Descuartizan a 3 en General Ter&#225;n ,3,0,0,0,0
+2011, 29 de Junio      ,25.593517,-99.990181, Dejan dos cuerpos en una camioneta ,0,0,0,0,0
+2011, 15 de Junio      ,25.593517,-99.990181, Aterra cifra mortal ,0,0,0,0,0
+2011, 11 de Junio      ,25.593517,-99.990181, Dejan a mutilado afuera de escuela ,0,0,0,0,0
+2011, 10 de Junio      ,25.593517,-99.990181, Encuentran narcococina en Cadereyta ,0,0,0,0,0
+2011, 7 de Junio      ,25.361711,-100.008202, Hallan 2 cuerpos en brecha de Cadereyta ,2,0,0,0,0
+2011, 5 de Junio      ,25.601902,-99.993439, Hallan a un encobijado en Cadereyta ,1,0,0,0,0
+2011, 1 de Junio      ,25.593517,-99.990181, Descuartizan a pelirroja en Cadereyta ,0,0,0,0,0
+2011, 26 de Junio      ,25.681137,-100.305176, Abate el Ej&#233;rcito a uno en tiroteo ,1,0,0,0, Armas Vehículos 
+2011, 3 de Junio      ,26.506905,-100.179453, Detiene Ej&#233;rcito a 6 con 912 mil d&#243;lares ,0,0,6,0, Armas Vehículos Dinero 
+2011, 8 de Junio      ,26.005573,-100.295906, Calcinan cuerpos en tambos ,0,0,0,0,0
+2011, 2 de Junio      ,25.963892,-100.294217, Destapa balacera cloaca del narco ,0,0,0,0,0
+2011, 7 de Mayo       ,25.637623,-100.322422, Balean en Valle Oriente a un polic&#237;a de San Pedro ,0,1,0,0,0
+2011, 5 de Mayo       ,25.637623,-100.322422, Rafaguean a polic&#237;a sampetrino ,0,0,0,0,0
+2011, 23 de Mayo       ,25.658239,-100.082703, Lo persiguen a balazos y muere al volcar ,1,0,0,0, Armas 
+2011, 22 de Mayo       ,25.638233,-100.115127, Mueren 5 al enfrentar a militares ,5,1,0,0,0
+2011, 20 de Mayo       ,-37.673412,-59.805103, Topan con Ej&#233;rcito; mueren 2 sicarios ,2,0,0,0, Armas Vehículos 
+2011, 3 de Mayo       ,25.635626,-100.18552, Encuentran en Ju&#225;rez cad&#225;ver encobijado ,1,0,0,0,0
+2011, 21 de Mayo       ,25.718014,-100.261701, Encuentran un muerto dentro de auto ,1,0,0,0,0
+2011, 15 de Mayo       ,25.714974,-100.272346, Muere baleado afuera de hospital ,1,0,0,0,0
+2011, 11 de Mayo       ,25.708092,-100.267711, Acribillan a 5 en una pickup ,5,0,0,0,0
+2011, 11 de Mayo       ,25.715206,-100.219688, Caen sin vida cuatro en enfrentamiento ,4,4,0,0,0
+2011, 9 de Mayo       ,25.751507,-100.31024, Tiran cuerpo torturado ,1,0,0,0,0
+2011, 31 de Mayo       ,25.64214,-100.286706, Lesionan a inocente en tiroteo ,0,0,0,0,0
+2011, 31 de Mayo       ,25.671893,-100.368738, Le queman patrulla a tr&#225;nsito ,0,0,0,0,0
+2011, 31 de Mayo       ,25.696381,-100.268428, Mata granadazo a un polic&#237;a regio ,0,0,0,0,0
+2011, 30 de Mayo       ,25.585143,-100.256467, Ejecutan en el Sur a 6 en bases de taxis ,5,0,0,0,0
+2011, 29 de Mayo       ,25.62926,-100.280581, Matan a inocente en persecuci&#243;n ,1,1,0,0, Drogas Vehículos 
+2011, 29 de Mayo       ,25.734274,-100.397013, Alarma tiroteo en Cumbres ,0,1,0,0, Armas Vehículos 
+2011, 29 de Mayo       ,25.641149,-100.317364, Alarma tiroteo en sector Valle Oriente ,0,0,0,0,0
+2011, 29 de Mayo       ,25.684043,-100.296872, Aseguran en operativos veh&#237;culos blindados ,0,0,0,0, Armas Vehículos 
+2011, 28 de Mayo       ,25.757413,-100.35592, Hieren a uno en ataque a balazos ,0,0,0,0,0
+2011, 28 de Mayo       ,25.588112,-100.253798, Ejecutan a otro en zona de La Estanzuela ,0,0,0,0,0
+2011, 27 de Mayo       ,25.763093,-100.412468, Enfrentan a ministeriales; fallece sicario en hospital ,0,0,0,0,0
+2011, 27 de Mayo       ,25.587607,-100.253858, Atacan base pirata; muere un inocente ,0,0,0,0,0
+2011, 27 de Mayo       ,25.641379,-100.304188, Lanzan r&#225;fagas contra casa ,0,0,0,0,0
+2011, 26 de Mayo       ,25.773344,-100.380042, Ejecutan a 7; hieren a ni&#241;a ,7,1,0,0,0
+2011, 25 de Mayo       ,25.70146,-100.330346, Lo hallan sin vida luego de balacera ,1,0,0,0,0
+2011, 24 de Mayo       ,25.6711,-100.33056, Ejecutan sicarios a mujer Tr&#225;nsito ,1,0,0,0,0
+2011, 24 de Mayo       ,25.661198,-100.324445, Fallece inocente durante una persecuci&#243;n ,1,0,0,0,0
+2011, 24 de Mayo       ,25.653751,-100.32114, Encuentran 5 asesinados en la Indepe ,5,0,0,0,0
+2011, 22 de Mayo       ,25.667513,-100.307289, Ejecutan a cuatro frente a Caf&#233; Iguana ,4,5,0,0,0
+2011, 19 de Mayo       ,25.635662,-100.293724, Ejecutan a 2 en San &#193;ngel ,2,0,0,0,0
+2011, 19 de Mayo       ,25.70716,-100.362218, Lo fusilan y le amputan dedo &#237;ndice ,1,0,0,0,0
+2011, 18 de Mayo       ,25.652765,-100.312731, Lo acribillan en Garza Sada ,1,0,0,0,0
+2011, 17 de Mayo       ,25.655362,-100.277189, Ejecutan a balazos a hombre dormido ,1,0,0,0,0
+2011, 16 de Mayo       ,25.6847,25.6847, Ejecutan a dos frente a un negocio ,2,0,0,0,0
+2011, 15 de Mayo       ,24.856534,-99.559479, Asesinan desde auto a joven en Linares ,1,0,0,0,0
+2011, 14 de Mayo       ,25.669322,-100.271355, Les pegaba banda tambi&#233;n a polic&#237;as ,0,0,4,0, Armas Vehículos Dinero 
+2011, 14 de Mayo       ,25.653083,-100.304188, Sale asaltante de una tienda y lo ejecutan ,1,0,0,0,0
+2011, 13 de Mayo       ,25.58528,-100.258699,  Encuentran un calcinado  ,1,0,0,0,0
+2011, 13 de Mayo       ,25.664728,-100.341018, Ejecutan a 2 sobre el T&#250;nel ,2,0,0,0,0
+2011, 12 de Mayo       ,25.578447,-100.244408, Persiguen y acribillan a uno en La Rioja ,1,0,0,0,0
+2011, 10 de Mayo       ,25.766484,-100.361298, Protege mujer a sus nietas y la asesinan ,1,0,0,0,0
+2011, 9 de Mayo       ,25.641488,-100.304103, Ejecutan a tres en un bar ,3,0,0,0,0
+2011, 9 de Mayo       ,25.576511,-100.237541, Le dan a taxista tiro de gracia ,1,0,0,0,0
+2011, 7 de Mayo       ,25.710743,-100.346983, Dejan camioneta con un ejecutado ,1,0,0,0,0
+2011, 5 de Mayo       ,25.665384,-100.295772, Ejecutan a cuatro en la Col. Caracol ,4,1,0,0,0
+2011, 5 de Mayo       ,25.66666,-100.304603, Matan sicarios a 8 y hieren a otros 3 ,1,0,0,0,0
+2011, 3 de Mayo       ,25.681137,-100.305176, Aparecen narcomantas en la Ciudad ,0,0,0,0,0
+2011, 1 de Mayo       ,25.723016,-100.334423, Liberan a 6 secuestrados y cae plagiario ,0,0,1,6, Armas Vehículos 
+2011, 31 de Mayo       ,25.668418,25.668418, Dejan cuerpo junto a Polic&#237;a ,0,0,0,0,0
+2011, 31 de Mayo       ,25.702674,-100.165994, Detienen partido para ejecutarlo ,0,0,0,0,0
+2011, 28 de Mayo       ,25.653878,-100.190149, Aseguran 6 fusiles balas y granadas ,0,0,0,0,0
+2011, 28 de Mayo       ,25.668418,-100.21549, Encuentran a 2 mutilados dentro de taxi ,0,0,0,0,0
+2011, 25 de Mayo       ,25.682762,-100.230589, Hallan cabeza de mujer dentro de taxi ,1,0,0,0,0
+2011, 21 de Mayo       ,25.664454,-100.26482, Matan a polic&#237;a en auto robado ,1,0,0,0, Vehículos 
+2011, 20 de Mayo       ,25.698748,-100.203945, Desaf&#237;an a Guadalupe con mutilada y recado ,1,0,0,0,0
+2011, 18 de Mayo       ,25.668418,-100.21549, Dejan dos decapitados junto a sede policiaca ,0,0,0,0,0
+2011, 18 de Mayo       ,25.655529,-100.17275, Emboscan y ejecutan a 3 polis de Guadalupe ,3,0,0,0, Armas Vehículos 
+2011, 17 de Mayo       ,25.684139,-100.250999, Asesinan a mujer y tiran el cuerpo ,1,0,0,0,0
+2011, 16 de Mayo       ,25.700878,-100.244187, Mueren al enfrentar a uniformados ,2,0,0,0,0
+2011, 16 de Mayo       ,25.694651,-100.192038, Acribillan a siete en un lote bald&#237;o ,7,0,0,0,0
+2011, 13 de Mayo       ,25.665795,-100.216026, Huyen sicarios a balazos y abandonan armamento ,0,0,0,0, Armas 
+2011, 11 de Mayo       ,25.657949,-100.189626, Emboscan y matan a una mujer polic&#237;a ,1,1,0,0,0
+2011, 10 de Mayo       ,25.65174,-100.1863, Muere un pistolero tras ataque a agentes ,1,4,0,0, Armas Vehículos 
+2011, 9 de Mayo       ,25.656073,-100.183983, Muere tras disparar a polis de Guadalupe ,1,0,5,0,0
+2011, 8 de Mayo       ,25.659768,-100.210456, Desatan tiroteos en Guadalupe ,4,0,0,0,0
+2011, 8 de Mayo       ,25.716401,-100.194841, Desatan tiroteos en Guadalupe ,0,4,3,0,0
+2011, 4 de Mayo       ,25.698589,-100.260714, Ejecutan a ex polic&#237;a y a otros dos hombres ,3,0,0,0,0
+2011, 3 de Mayo       ,25.652707,-100.198102, Caen hijos de grupero con 3 autos robados ,0,0,6,0, Vehículos 
+2011, 2 de Mayo       ,25.670087,-100.145818, Ejecutan a 6 en Guadalupe ,6,0,0,0,0
+2011, 31 de Mayo       ,25.757364,-100.235314, Balean a mando y escolta de Apodaca ,0,0,0,0,0
+2011, 25 de Mayo       ,25.792357,-100.177631, Abaten militares a seis pistoleros ,6,4,0,0, Vehículos 
+2011, 25 de Mayo       ,25.802673,-100.194626, Ejecutan a hombre recostado en su cama ,1,1,0,0,0
+2011, 24 de Mayo       ,25.840685,-100.246124, Matan a celador de Apodaca ,1,0,0,0,0
+2011, 20 de Mayo       ,25.857792,-100.245091, Indagan si fuego fue provocado ,14,0,0,0,0
+2011, 18 de Mayo       ,25.671243,-100.144371, Cae banda con arsenal en Apodaca ,0,0,6,0, Armas Vehículos 
+2011, 13 de Mayo       ,25.74154,-100.16103, Salen ilesos polic&#237;as en ataque a balazos ,0,1,0,0, Armas Vehículos 
+2011, 10 de Mayo       ,25.776832,-100.232166, Iban por el hijo; ejecutan al pap&#225; ,1,0,0,0,0
+2011, 6 de Mayo       ,25.759318,-100.172293, Pistoleros regresan 2 cuerpos ,0,0,0,0,0
+2011, 5 de Mayo       ,25.781562,-100.187597, Ejecuta comando a 5 en Apodaca ,5,0,0,0, Vehículos 
+2011, 2 de Mayo       ,25.753027,-100.240736, Matan a 2 en Apodaca ,2,0,0,0,0
+2011, 1 de Mayo       ,25.760552,-100.249279, Abaten a 2 pistoleros en un enfrentamiento ,2,0,0,0,0
+2011, 19 de Mayo       ,25.765422,-100.309482, Disparan a patrullas de Escobedo ,0,0,0,0,0
+2011, 12 de Mayo       ,25.814019,-100.272632, Hallan muerto cerca de PGR ,1,0,0,0, Vehículos 
+2011, 6 de Mayo       ,25.800237,-100.416357, Hallan plagiadas a abuela y su nieta ,1,0,2,9, Armas Vehículos 
+2011, 6 de Mayo       ,25.800237,-100.416357, Frena tiroteo vida de inocente  ,1,6,0,0, Armas 
+2011, 24 de Mayo       ,25.957119,-100.163727, Muere pistolero en persecuci&#243;n ,1,0,0,0, Armas Vehículos 
+2011, 4 de Mayo       ,24.864448,-99.571173, Confirman en Linares 3 sicarios muertos  ,3,0,0,1, Armas Vehículos 
+2011, 1 de Mayo       ,24.8438,-99.561839, Encuentran asesinado a un obrero levantado ,1,0,0,0,0
+2011, 21 de Mayo       ,25.680415,-100.474082, Ejecutan a tr&#225;nsito de Santa Catarina ,1,0,0,0,0
+2011, 10 de Mayo       ,25.686629,-100.421605, Acribillan a 2 polis junto a su patrulla ,2,0,0,0,0
+2011, 3 de Mayo       ,25.704704,-100.513791, Balean a 2 polic&#237;as de Santa Catarina ,0,2,0,0,0
+2011, 23 de Mayo       ,25.447692,-100.154371, Tiran cuerpo baleado afuera de pante&#243;n ,1,0,0,0,0
+2011, 22 de Mayo       ,25.536866,-100.204926, Le destrozan el rostro al ejecutarlo ,1,0,0,0,0
+2011, 17 de Mayo       ,25.549624,-100.224292, Investigan una muerte ,1,0,0,0,0
+2011, 27 de Mayo       ,25.283611,-100.020278, Levantan y ejecutan a 2 hermanos en Allende ,0,0,0,0,0
+2011, 29 de Mayo       ,25.176359,-99.867096, Acribillan a mujer en Montemorelos ,1,0,0,0,0
+2011, 20 de Mayo       ,25.183496,-99.829679, Hallan a hombre asesinado ,1,0,0,0,0
+2011, 17 de Mayo       ,25.183496,-99.829679, Calienta amenaza a la zona citr&#237;cola ,0,0,0,0,0
+2011, 15 de Mayo       ,25.176359,-99.842377, Tiran tres cuerpos descuartizados ,3,0,0,0,0
+2011, 12 de Mayo       ,25.092284,-99.799976, Levantan a Secretario en Linares ,0,0,0,1,0
+2011, 28 de Mayo       ,25.703331,-99.236522, Hallan en China a un decapitado envuelto en cobija ,0,0,0,0,0
+2011, 29 de Mayo       ,25.58704,-99.997559, Lo abaten en enfrentamiento ,0,0,0,0,0
+2011, 23 de Mayo       ,25.604844,-100.031633, Hallan 5 cuerpos en una narcofosa ,5,0,0,0,0
+2011, 18 de Mayo       ,25.593517,-99.990181, Hallan 2 cuerpos en noria ,2,0,0,0,0
+2011, 4 de Mayo       ,25.386837,-100.429459, Mueren 2 en Los Aldamas ,2,0,0,0, Armas 
+2011, 9 de Mayo       ,26.230606,-99.482574, Fallece sicario en enfrentamiento ,1,0,0,0,0
+2011, 31 de Mayo       ,26.659711,-99.986935, Asesinan y queman a mujer ,0,0,0,0,0
+2011, 23 de Mayo       ,25.963892,-100.294217, La esposan y la ejecutan en camioneta ,1,0,0,0, Vehículos 
+2011, 27 de Abril      ,25.633943,-100.087681, Mueren 4 a tiros en enfrentamiento ,4,0,0,0, Armas Vehículos 
+2011, 5 de Abril      ,25.647326,-100.094528, Mueren 5 a balazos; dejan grave a ni&#241;a ,5,1,13,0, Vehículos 
+2011, 17 de Abril      ,25.759258,-100.314857, Tiran un muerto con balazo en la cabeza ,1,0,0,0,0
+2011, 8 de Abril      ,25.717937,-100.224968, Chocan y levantan a 2 ,0,0,0,0,0
+2011, 8 de Abril      ,25.713302,-100.257033, Abandonan camioneta con ejecutado ,1,0,0,0, Vehículos 
+2011, 7 de Abril      ,25.742456,-100.301789, Caen dos mujeres halcones ,0,0,2,0,0
+2011, 5 de Abril      ,25.728941,-100.309689, Deja narcoviolencia 14 muertos en un d&#237;a  ,1,0,0,0,0
+2011, 5 de Abril      ,25.763075,-100.298222, Caen 2 tr&#225;nsitos halcones ,0,0,2,0, Drogas Vehículos 
+2011, 1 de Abril      ,25.718014,-100.261701, Suman 8 muertos en otro d&#237;a violento ,3,0,0,0,0
+2011, 1 de Abril      ,25.718014,-100.261701, Suman 8 muertos en otro d&#237;a violento ,1,0,0,0,0
+2011, 26 de Abril      ,25.727888,-100.349464, Asesinan a un empleado estatal ,1,0,0,0,0
+2011, 26 de Abril      ,25.641507,-100.306259, Plagian y balean a un escribiente ,0,1,1,0,0
+2011, 24 de Abril      ,25.728719,-100.368798, Ejecutan a oficial frente a iglesia ,1,0,0,0,0
+2011, 24 de Abril      ,25.658478,-100.324594, Aparece asesinado tras ser levantado ,1,0,0,0,0
+2011, 22 de Abril      ,25.681137,-100.305176, Toman represalia: atacan Monterrey ,1,2,0,0,0
+2011, 22 de Abril      ,25.673211,-100.309201, Desaparece escolta de mando ,0,0,0,0,0
+2011, 18 de Abril      ,25.61862,-100.281315, Denuncia ejecuci&#243;n; indagar&#225;n balacera ,1,0,0,0, Armas 
+2011, 17 de Abril      ,25.701653,-100.351428, Abate Ej&#233;rcito a tres en Fomerrey 116 ,3,4,0,0,0
+2011, 15 de Abril      ,25.538536,-100.206049, Ejecutan a conductor ,1,0,0,0, Vehículos 
+2011, 12 de Abril      ,25.610842,-100.271015, Ejecutan a uno y hieren a inocente ,1,1,0,0, Vehículos 
+2011, 11 de Abril      ,25.726931,-100.349212, Ejecutan a Celador del Penal del Topo Chico ,1,0,0,0,0
+2011, 10 de Abril      ,25.58193,-100.243979, Ejecutan a dos en vulcanizadora ,2,0,0,0,0
+2011, 9 de Abril      ,25.698946,-100.286656, Ejecutan a uno en la Moderna ,1,2,0,0,0
+2011, 8 de Abril      ,25.698946,-100.286656, Se topan marinos con convoy de sicarios ,0,0,0,0, Vehículos 
+2011, 6 de Abril      ,25.647224,-100.29099, Regresa el terror a la zona Tec ,0,0,0,0,0
+2011, 6 de Abril      ,25.636342,-100.315003, Deja narcoviolencia 14 muertos en un d&#237;a  ,1,0,0,0,0
+2011, 5 de Abril      ,25.699443,-100.341369, Deja narcoviolencia 14 muertos en un d&#237;a  ,2,0,0,0,0
+2011, 5 de Abril      ,25.587607,-100.253858, Deja narcoviolencia 14 muertos en un d&#237;a  ,2,0,0,0,0
+2011, 5 de Abril      ,25.768083,-100.406868, Deja narcoviolencia 14 muertos en un d&#237;a  ,1,0,0,0,0
+2011, 4 de Abril      ,25.670868,-100.285521, Atacan a casino con granadazo ,0,1,0,0,0
+2011, 2 de Abril      ,25.714207,-100.370142, Detienen a pistolero tras tiroteo ,0,0,1,0, Armas Vehículos 
+2011, 1 de Abril      ,25.763093,-100.412468, Atacan delegaci&#243;n de la Polic&#237;a Regia  ,0,0,0,0,0
+2011, 1 de Abril      ,25.739085,-100.336255, Suman 8 muertos en otro d&#237;a violento ,4,0,0,0,0
+2011, 1 de Abril      ,25.768615,-100.365931, Suman 8 muertos en otro d&#237;a violento ,1,0,0,0,0
+2011, 30 de Abril      ,25.739021,-100.33704, Reclaman asalto; los matan a tiros ,3,0,0,0,0
+2011, 30 de Abril      ,25.785,-100.051111, Detiene Ej&#233;rcito a 4 plagiarios ,0,0,4,0, Armas Vehículos 
+2011, 26 de Abril      ,25.666207,-100.174198, Ejecutan a un poli; dejan grave a otro ,1,1,0,0,0
+2011, 22 de Abril      ,25.728104,-100.194841, Detectan cartuchos para cuerno de chivo ,0,0,0,0,0
+2011, 21 de Abril      ,25.604222,-100.270318, Tiran en el r&#237;o a 2 ejecutados ,2,0,0,0,0
+2011, 15 de Abril      ,25.694883,-100.192417, Matan a 2; tiran a uno en el R&#237;o ,2,0,0,0,0
+2011, 13 de Abril      ,25.708672,-100.192008, Ejecutan a dos junto a capillas ,2,0,0,0,0
+2011, 12 de Abril      ,25.728158,-100.199089, Baja de auto robado y lo ejecutan ,1,0,0,0,0
+2011, 12 de Abril      ,25.681021,-100.168437, Balean a mujer en Guadalupe ,0,1,0,0,0
+2011, 11 de Abril      ,25.674794,-100.204625, Muere sicario a balazos en Guadalupe ,1,0,4,8, Armas Vehículos 
+2011, 8 de Abril      ,25.699108,-100.204715, Hallan auto baleado ,0,0,0,0, Vehículos 
+2011, 8 de Abril      ,25.69785,-100.219362, Rescata Ej&#233;rcito a 6 tras enfrentamiento ,0,1,0,0,0
+2011, 7 de Abril      ,25.66924,-100.159832, Atacan con granda Delegaci&#243;n Santa Cruz ,0,0,0,0,0
+2011, 5 de Abril      ,25.647431,-100.202897, Deja narcoviolencia 14 muertos en un d&#237;a  ,1,0,0,0,0
+2011, 3 de Abril      ,25.665395,-100.213852, Abaten a dos pistoleros en enfrentamiento en Guadalupe ,2,0,0,0,0
+2011, 1 de Abril      ,25.651332,-100.221679, Realiza Ej&#233;rcito operativo en Guadalupe ,0,0,0,0,0
+2011, 1 de Abril      ,25.683604,-100.165156, Hace decomisos la Marina ,0,0,3,0, Drogas Armas Vehículos 
+2011, 19 de Abril      ,25.752536,-100.186173, Lo ejecutan de 5 balazos en Apodaca ,1,0,0,0,0
+2011, 16 de Abril      ,25.757228,-100.362339, Hallan enterrados a tres ejecutados ,3,0,0,0,0
+2011, 12 de Abril      ,25.790927,-100.427055, Acribillan a mujer; hija resulta herida ,6,1,0,0,0
+2011, 30 de Abril      ,25.808391,-100.319767, Hallan un muerto en R&#237;o Pesquer&#237;a ,1,0,0,0,0
+2011, 26 de Abril      ,24.842204,-99.573212, Encuentra ejecutado a velador en Linares ,1,0,0,0,0
+2011, 24 de Abril      ,24.870435,-99.578447, Atacan Polic&#237;a Ministerial en Linares ,0,0,0,0,0
+2011, 19 de Abril      ,24.87406,-99.576828, Atacan a inocentes y asesinan a mujer ,1,1,0,0,0
+2011, 15 de Abril      ,38.09362,-3.635845, Fallecen 2 pistoleros al enfrentar a Ej&#233;rcito ,2,0,0,0, Vehículos 
+2011, 24 de Abril      ,24.888227,-99.673805, Atacan comandancia de Hualahuises ,0,0,0,0,0
+2011, 15 de Abril      ,24.883808,-99.67517, Dejan 3 decapitados frente a una iglesia ,3,0,0,0,0
+2011, 2 de Abril      ,25.801021,-100.392614, Detienen a halcones en Garc&#237;a ,0,0,3,0, Vehículos 
+2011, 29 de Abril      ,25.702639,-100.514603, Lo torturan y ejecutan junto a la Santa Muerte ,1,0,0,0,0
+2011, 29 de Abril      ,25.674214,-100.423322, Balean a dos polic&#237;as municipales ,0,2,0,0,0
+2011, 9 de Abril      ,25.673763,-100.460598, Estalla granada en Santa Catarina ,0,1,0,0,0
+2011, 21 de Abril      ,25.426964,-100.151683, Matan sicarios a 2; otro queda herido ,2,1,0,0,0
+2011, 5 de Abril      ,25.426964,-100.151683, Deja narcoviolencia 14 muertos en un d&#237;a  ,1,0,0,0,0
+2011, 7 de Abril      ,25.283611,-100.020278, Ejecutan a dos tr&#225;nsitos ,2,0,0,0,0
+2011, 22 de Abril      ,25.183496,-99.829679, Encuentran un ejecutado ,1,0,0,0,0
+2011, 15 de Abril      ,25.183496,-99.829679, Abaten militares a 3 tras una persecuci&#243;n ,3,0,0,1, Armas Vehículos 
+2011, 7 de Abril      ,25.183496,-99.829679, Rescata grupo armado a detenido ,0,0,0,1,0
+2011, 6 de Abril      ,25.183496,-99.829679, Rafaguean a dos polic&#237;as ,0,0,0,0,0
+2011, 3 de Abril      ,25.181331,-99.83963, Hallan a ejecutado en Montemorelos ,1,0,0,0,0
+2011, 7 de Abril      ,25.25382,-99.678077, Atacan Polic&#237;a de Ter&#225;n ,0,0,0,0, Armas 
+2011, 11 de Abril      ,25.703331,-99.236522, Capturan a 10 sicarios en 4 operativos ,0,0,10,0, Drogas Armas Vehículos 
+2011, 22 de Abril      ,25.792576,-99.178629, Libera Ej&#233;rcito a 2 plagiados ,0,0,1,2, Armas Vehículos 
+2011, 18 de Abril      ,25.592304,-100.011978, Capturan militares a 2 por halconeo ,0,0,2,0,0
+2011, 16 de Abril      ,25.593517,-99.990181, Acribillan a dos afuera de un dep&#243;sito ,2,0,0,0,0
+2011, 15 de Abril      ,25.593517,-99.990181, Roban cuerpos de cuatro ,0,0,0,0,0
+2011, 7 de Abril      ,25.577577,-100.007602, Abate Ej&#233;rcito a dos pistoleros ,2,0,3,0, Armas Vehículos 
+2011, 9 de Abril      ,27.024459,-100.508013, Detienen en Lampazos a jefe de Polic&#237;a ,0,0,1,0,0
+2011, 27 de Marzo      ,25.670888,-100.397959, Detiene Marina a mec&#225;nico en San Pedro ,0,0,1,0, Armas Vehículos 
+2011, 5 de Marzo      ,25.652107,-100.339229, Libran polic&#237;as de San Pedro ataque a balazos ,0,2,0,0,0
+2011, 5 de Marzo      ,25.662223,-100.409675, Captura Marina a 4 en San Pedro ,0,0,4,0, Drogas Armas Vehículos 
+2011, 17 de Marzo      ,29.150696,-110.958104, Catea Marina vivienda y bodega ,0,0,0,0,0
+2011, 1 de Marzo      ,25.647368,-100.145445, Ejecutan a 2 se llevan cuerpos y regresan a uno ,2,0,0,0,0
+2011, 1 de Marzo      ,25.626669,-100.16819, Ejecutan a dos  ,2,0,1,0,0
+2011, 28 de Marzo      ,25.738306,-100.289834, Tiran cad&#225;ver esposado ,1,0,0,0,0
+2011, 27 de Marzo      ,25.762639,-100.238743, Ejecutan a dos; hieren a inocente ,2,1,1,0,0
+2011, 23 de Marzo      ,25.752581,-100.298154, Ejecutan uno frente a esposa ,1,1,0,0,0
+2011, 21 de Marzo      ,25.738915,-100.277603, Acribillan a dos frente a dep&#243;sito ,2,0,0,0,0
+2011, 11 de Marzo      ,25.701272,-100.300687, Tienen mujeres d&#237;a negro: asesinan a 3 ,2,0,0,0,0
+2011, 10 de Marzo      ,701272,-100.300687, Mueren en enfrentamiento 3 pistoleros ,3,0,0,0, Drogas Armas Vehículos 
+2011, 3 de Marzo      ,25.754735,-100.247315, Balean a 2 ex ministeriales ,0,2,0,0, Vehículos 
+2011, 3 de Marzo      ,25.756706,-100.259986, Mata a novios en San Nicol&#225;s ,2,0,0,0,0
+2011, 28 de Marzo      ,25.706062,-100.328779, Deja ejecuci&#243;n civil muerto y 4 heridos ,2,4,0,0,0
+2011, 27 de Marzo      ,25.686271,-100.287355, Capturan otra vez a narco pesado ,0,0,2,0, Drogas Vehículos 
+2011, 23 de Marzo      ,25.746803,-100.354, Abate Ej&#233;rcito a 3 ,3,0,0,0,0
+2011, 23 de Marzo      ,25.681137,-100.305176, Muere sicario en balacera ,1,0,1,0, Armas Vehículos 
+2011, 22 de Marzo      ,25.697922,-100.28389, Detienen a 5 por halconear en la Moderna ,0,0,5,0, Drogas Vehículos 
+2011, 20 de Marzo      ,25.669901,-100.382874, Acribillan a tr&#225;nsito regio en Blvd. D&#237;az Ordaz ,1,0,0,0,0
+2011, 20 de Marzo      ,25.751971,-100.365772, Rafaguean a dos; uno muere ,1,1,0,0,0
+2011, 16 de Marzo      ,25.752976,-100.358133, Emboscan y balean a polic&#237;as federales ,0,3,1,0, Armas Vehículos 
+2011, 14 de Marzo      ,25.639398,-100.284576, Explota granada en plaza comercial ,0,1,0,0,0
+2011, 14 de Marzo      ,25.717294,-100.346718, Balean a hombre y 2 hijos ,0,3,0,0,0
+2011, 14 de Marzo      ,25.613353,-100.268204, Libran cinco polic&#237;as ataque a balazos ,0,0,1,0, Vehículos 
+2011, 13 de Marzo      ,25.684077,-100.351675, Detienen a pistoleros en Gonzalitos afuera de Rancho Viejo ,0,0,2,0, Drogas Armas 
+2011, 13 de Marzo      ,25.676593,-100.352147, Caen dos robacoches cerca del Hotel Hampton Inn ,0,0,2,0, Armas Vehículos 
+2011, 12 de Marzo      ,25.684502,-100.317836, Alertan balazos a federales en hotel ,0,0,0,0,0
+2011, 12 de Marzo      ,25.706004,-100.342496, Dan 2 balazos a polic&#237;a regio en persecuci&#243;n ,0,2,0,0,0
+2011, 12 de Marzo      ,25.642586,-100.312956, Detienen a 8 tras ataque contra polic&#237;as ,0,0,8,0, Drogas Vehículos Dinero 
+2011, 11 de Marzo      ,25.697699,-100.335054, Tienen mujeres d&#237;a negro: asesinan a 3 ,1,0,0,0,0
+2011, 9 de Marzo      ,25.690366,-100.298899, Lanzan explosivo a tienda ,0,0,0,0,0
+2011, 8 de Marzo      ,25.687325,-100.310841, Hieren a beb&#233; durante ejecuci&#243;n ,1,1,0,0,0
+2011, 5 de Marzo      ,25.646492,-100.309449, Caen 2 narcos en La Risca ,0,0,4,0, Drogas Armas Vehículos 
+2011, 3 de Marzo      ,25.680238,-100.311291, Catea Marina sede sindical ,0,0,1,0, Armas 
+2011, 2 de Marzo      ,25.611268,-100.271187, Atacan ret&#233;n con granadas; lesionan a mujer ,0,1,0,0,0
+2011, 2 de Marzo      ,25.655183,-100.316548, Atacan Cuartel Sur de Polic&#237;a ,0,0,3,0, Armas 
+2011, 2 de Marzo      ,25.724717,-100.344572, Catean el Topo Chico; detienen a celador ,0,0,1,0, Drogas Armas 
+2011, 1 de Marzo      ,25.774465,-100.361974, Abate Grupo de Reacci&#243;n a pistolero ,1,0,0,0, Armas 
+2011, 31 de Marzo      ,25.665124,-100.213852, Abaten a 4 en tiroteo ,4,0,0,0,0
+2011, 30 de Marzo      ,25.711711,-100.205641, Matan sicarios a 3 j&#243;venes en 40 minutos ,3,0,0,0,0
+2011, 29 de Marzo      ,25.683604,-100.165156, Caen 7 con arsenal tras enfrentamiento ,0,0,7,0, Armas Vehículos 
+2011, 28 de Marzo      ,25.674717,-100.210805, Detienen a 5 al enfrentarse con Polic&#237;a ,0,1,5,0, Vehículos 
+2011, 26 de Marzo      ,25.718628,-100.195334, Rescatan sicarios a dos muertos en Guadalupe ,0,0,0,0,0
+2011, 16 de Marzo      ,25.688244,-100.233325, Matan a dos y hieren a uno en Guadalupe ,2,1,0,0,0
+2011, 15 de Marzo      ,25.692353,-100.245266, Lanzan granada contra patrulla ,0,0,0,0,0
+2011, 15 de Marzo      ,25.656614,-100.268741, Lidera una mujer grupo de halcones ,0,0,3,0, Vehículos 
+2011, 13 de Marzo      ,25.6898,-100.163898, Cae en enfrentamiento menor de 16 a&#241;os ,0,1,1,0, Armas Vehículos 
+2011, 9 de Marzo      ,25.716337,-100.18933, Regresan ataques a Polic&#237;a ,0,0,0,0,0
+2011, 8 de Marzo      ,25.69338,-100.219285, Cae abatido a balazos en narcobloqueo ,1,0,0,0, Armas 
+2011, 3 de Marzo      ,25.658761,-100.260694, Balean a tr&#225;nsito ,0,1,0,0,0
+2011, 2 de Marzo      ,25.687499,-100.213294, Atacan cuartel y destruyen 6 patrullas ,0,0,0,0,0
+2011, 7 de Marzo      ,25.648909,-100.171376, Enfrenta a ladr&#243;n y muere baleado ,1,0,0,0,0
+2011, 6 de Marzo      ,25.684736,-100.213406, Lo asesinan al resistirse a ser asaltado ,1,0,0,0,0
+2011, 23 de Marzo      ,25.768952,-100.254211, Mueren 3 sicarios en tiroteo ,3,0,0,1, Armas Vehículos 
+2011, 16 de Marzo      ,25.7917,-100.252733, Acribillan a escolta &#233;lite de Clara Luz ,1,0,0,0,0
+2011, 16 de Marzo      ,25.835123,-100.212822, Atacan a balazos a Polic&#237;a de Apodaca ,0,0,0,0, Armas 
+2011, 4 de Marzo      ,25.715459,-100.152529, Abandonan auto baleado y con sangre ,0,0,0,0,0
+2011, 2 de Marzo      ,25.736045,-100.207844, Ejecutan en gasolinera ,1,0,0,0,0
+2011, 29 de Marzo      ,25.795657,-100.29437, Mueren 4 contra Ej&#233;rcito en Escobedo ,5,0,0,0, Armas Vehículos 
+2011, 8 de Marzo      ,25.79284,-100.317879, Muere sicario y escapan 10 tras balacera ,1,0,0,0, Armas Vehículos 
+2011, 7 de Marzo      ,25.770098,-100.319316, Hallan granada en Escobedo ,0,0,0,0, Armas 
+2011, 7 de Marzo      ,25.771953,-100.316892, Ejecutan a taxista ,1,0,0,0,0
+2011, 24 de Marzo      ,25.955113,-100.163749, Muere en tiroteo en Carretera a Laredo  ,1,0,0,0, Armas Vehículos 
+2011, 25 de Marzo      ,24.85787,-99.566328, Abate Ej&#233;rcito a uno en Linares ,1,0,0,0,0
+2011, 23 de Marzo      ,24.871992,-99.576396, Ejecutan a agente de Tr&#225;nsito ,4,0,0,0,0
+2011, 11 de Marzo      ,24.822924,-100.074472, Hallan coca; vale 13 mdp ,0,0,2,0, Drogas Armas Vehículos 
+2011, 29 de Marzo      ,25.78799,-100.490742, Acechan a Alcalde: libra nuevo ataque ,1,5,1,0, Vehículos 
+2011, 24 de Marzo      ,25.80336,-100.389473, Acaba tiroteo en volcadura; capturan a 2 ,0,0,2,0, Armas Vehículos 
+2011, 11 de Marzo      ,25.80336,-100.389473, Rescata el Ej&#233;rcito a 3; caen plagiarios ,0,0,3,3, Armas Vehículos 
+2011, 9 de Marzo      ,25.698985,-100.455891, Atacan con granadas edificio municipal ,0,0,0,0,0
+2011, 25 de Marzo      ,25.283611,-100.020278, Ejecutan a uno en Allende ,1,0,0,0,0
+2011, 11 de Marzo      ,25.283611,-100.020278, Tienen mujeres d&#237;a negro: asesinan a 3 ,1,0,0,0,0
+2011, 4 de Marzo      ,25.283611,-100.020278, Ejecutan a uno y balean a 2 ,1,2,0,0,0
+2011, 3 de Marzo      ,25.283611,-100.020278, Desaparece mando de Polic&#237;a de Allende ,0,0,0,0,0
+2011, 27 de Marzo      ,25.160201,25.160201, Hallan a ejecutado en Montemorelos ,1,0,0,0,0
+2011, 23 de Marzo      ,25.188655,-99.814129, Muere uno en enfrentamiento ,1,0,0,0, Armas Vehículos 
+2011, 3 de Marzo      ,25.183496,-99.829679, Descuartizan y arrancan cara a hombre ,1,0,0,0,0
+2011, 13 de Marzo      ,25.69506,-99.233665, Retan a militares; mueren 4 sicarios ,4,0,4,0, Armas Vehículos 
+2011, 8 de Marzo      ,25.710218,-99.235725, Encuentran 2 descuartizados y con las cabezas calcinadas ,2,0,0,0, Vehículos 
+2011, 24 de Marzo      ,25.585239,-99.998573, Calcinan cuerpo tras decapitarlo ,1,0,0,0,0
+2011, 20 de Marzo      ,25.596948,-99.992065, Hallan a descuartizado en camioneta en Cadereyta ,1,0,0,0,0
+2011, 3 de Marzo      ,25.513939,-100.007, Muere pistolero en Cadereyta ,1,0,1,0, Vehículos 
+2011, 3 de Marzo      ,25.698735,-99.624754, Tiran a mutilado en Los Ramones ,1,0,0,0,0
+2011, 7 de Marzo      ,25.698735,-99.624754, Tiran a descuartizado en Los Herreras ,1,0,0,0,0
+2011, 2 de Marzo      ,26.00286,-100.535083, Asesina y calcina a ni&#241;a ,1,0,0,0,0
+2011, 13 de Febrero    ,25.674562,-100.4071, Persiguen y balean a conductor ,0,2,0,0,0
+2011, 2 de Febrero    ,25.663683,-100.409299, Abate Marina a ex escolta de Mauricio ,4,0,1,0, Drogas Armas Vehículos 
+2011, 19 de Febrero    ,25.640443,-100.093861, Abate Ej&#233;rcito a 3 en Ju&#225;rez ,3,0,0,0, Armas Vehículos 
+2011, 8 de Febrero    ,25.666594,-100.104074, Abaten a 2 y  liberan a secuestrados ,2,1,0,4, Armas Vehículos 
+2011, 24 de Febrero    ,25.730787,-100.291464, Ejecutan a otro ligado a &quot;grupo rudo&quot; ,0,0,0,0,0
+2011, 24 de Febrero    ,25.722668,-100.217929, Detienen a dos polic&#237;as por halconear ,0,0,2,0,0
+2011, 12 de Febrero    ,25.754251,-100.276809, Liberan a mujer; mueren 7 sicarios ,8,2,0,1, Armas Vehículos 
+2011, 2 de Febrero    ,25.714665,-100.260694, Lanzan granadas a sede policiaca ,0,0,0,0,0
+2011, 24 de Febrero    ,25.723732,-100.267947, Asesinan a mujer; buscan a su pareja ,1,0,0,0,0
+2011, 28 de Febrero    ,25.615302,-100.264546, Balena y tiran a dos menores ,0,2,0,0,0
+2011, 28 de Febrero    ,25.762793,-100.372038, Atacan a granadazos cuartel estatal ,0,0,0,0,0
+2011, 26 de Febrero    ,25.705346,-100.326462, Ejecutan a halc&#243;n en tienda ,1,0,0,0,0
+2011, 26 de Febrero    ,25.668277,-100.320282, Ejecutan a asaltante ,1,0,1,0, Vehículos 
+2011, 25 de Febrero    ,25.65998,-100.287323, Ejecutan a conductor ,1,0,0,0,0
+2011, 25 de Febrero    ,25.729434,-100.371866, Lanzan granada falsa a cuartel ,0,0,0,0,0
+2011, 24 de Febrero    ,25.699855,-100.282323, Lo ejecutan en la Moderna ,1,0,0,0,0
+2011, 23 de Febrero    ,25.650289,-100.309371, Encuentran cuerpo torturado ,1,0,0,0,0
+2011, 22 de Febrero    ,25.631273,-100.286787, Abate Marina a 3 en Sierra Ventana ,3,0,0,0, Armas 
+2011, 19 de Febrero    ,25.755324,-100.382799, Cae pistolero tras atacar a polic&#237;as ,0,0,1,0, Vehículos 
+2011, 19 de Febrero    ,25.7202,-100.347684, Detiene Marina a 8 secuestradores ,0,0,8,1, Drogas Armas Vehículos 
+2011, 17 de Febrero    ,25.668083,-100.311795, Ejecutan a Tr&#225;nsito en cajero autom&#225;tico ,1,0,0,0,0
+2011, 17 de Febrero    ,25.638296,-100.279534, Asesinan a hombre en Contry ,1,0,0,0,0
+2011, 17 de Febrero    ,25.639031,-100.284555, Golpean y balean a ministeriales ,0,1,0,0,0
+2011, 17 de Febrero    ,25.65872,-100.317516, Agreden a ministerial ,0,1,0,0,0
+2011, 17 de Febrero    ,25.659902,-100.275156, Golpean y balean a polic&#237;a ,0,1,0,0,0
+2011, 17 de Febrero    ,25.689452,-100.332749, Agreden a polic&#237;a ,0,1,0,0,0
+2011, 16 de Febrero    ,25.704708,-100.279663, Ejecutan a pareja dentro de auto ,2,0,0,0, Vehículos 
+2011, 16 de Febrero    ,25.773364,-100.366309, Lo ejecutan cerca de su casa ,1,0,0,0, Vehículos 
+2011, 16 de Febrero    ,25.721934,-100.343499, Detienen a 3 narcos en tiroteo ,0,0,3,0, Armas Vehículos 
+2011, 16 de Febrero    ,25.639128,-100.284705, Movilizan balazos en s&#250;per ,0,0,0,0,0
+2011, 16 de Febrero    ,25.692983,-100.322032, Causa movilizaci&#243;n supuesto explosivo ,0,0,0,0,0
+2011, 15 de Febrero    ,25.655183,-100.27874, Balean casino Jubile&#233; ,0,2,0,0,0
+2011, 15 de Febrero    ,25.670153,-100.333521, Moviliza reporte de detonaciones ,0,0,0,0,0
+2011, 13 de Febrero    ,25.657368,-100.328972, Balea comando a comerciante en su casa ,0,1,0,0,0
+2011, 13 de Febrero    ,25.675839,-100.326891, Ejecutan al director del C5 ,1,0,3,0,0
+2011, 11 de Febrero    ,25.686736,-100.314864, Ejecuta comando a lavachoches ,3,0,0,0, Armas 
+2011, 7 de Febrero    ,25.626553,-100.291915, Ejecutan y dan tiro de gracia ,1,0,0,0,0
+2011, 7 de Febrero    ,25.643499,-100.287817, Balean a hombre dentro del S&#250;per ,0,1,0,0,0
+2011, 7 de Febrero    ,25.68223,-100.321709, Ejecutan en estacionamiento de table ,1,0,0,0,0
+2011, 5 de Febrero    ,25.72348,-100.342255, Mutilan a mando del Topo Chico ,1,0,0,0,0
+2011, 5 de Febrero    ,25.662107,-100.313051, Persiguen y balean a hombre ,0,2,0,0,0
+2011, 4 de Febrero    ,25.629455,-100.293943, Ejecutan a comerciante ,1,0,0,0,0
+2011, 3 de Febrero    ,25.685701,-100.300412, Caen narcos con droga ,0,0,2,0, Drogas Armas Vehículos 
+2011, 2 de Febrero    ,25.704573,-100.340109, Balean a celadores del Topo Chico ,0,3,0,0,0
+2011, 1 de Febrero    ,25.640946,-100.281143, Atacan ret&#233;n con granada ,0,0,0,0,0
+2011, 13 de Febrero    ,25.538536,-100.206049, Mata ministerial a novia y se suicida ,2,0,0,0,0
+2011, 10 de Febrero    ,25.785,-100.051111, Hallan a mujer con 78 pu&#241;aladas ,1,0,0,0,0
+2011, 28 de Febrero    ,25.708014,-100.199432, Ejecutan arde camioneta y roban cuerpo quemado ,1,0,0,0,0
+2011, 27 de Febrero    ,25.672338,-100.259643, Balean a 4 menores y fallece 1 ,1,3,0,0,0
+2011, 26 de Febrero    ,25.705037,-100.208101, Hallan soldados armas en camioneta ,0,0,0,0, Vehículos 
+2011, 22 de Febrero    ,25.705946,-100.210022, Mueren 2 al enfrentar a militares ,2,0,0,0, Armas 
+2011, 20 de Febrero    ,25.665472,-100.214067, Caen 2 polic&#237;as de Guadalupe con droga ,0,0,2,0, Drogas 
+2011, 19 de Febrero    ,25.730188,-100.192888, Ejecutan a 6; roban cuerpos y los regresan ,6,0,0,0,0
+2011, 19 de Febrero    ,25.671719,-100.263548, Caen 2 polic&#237;as halcones ,0,0,2,0,0
+2011, 18 de Febrero    ,25.64555,-100.174456, Abate Ej&#233;rcito a 5 en Guadalupe ,5,0,0,0, Armas Vehículos 
+2011, 16 de Febrero    ,25.658916,-100.190935, Abate Ej&#233;rcito a 4 pistoleros ,4,0,0,0, Armas Vehículos 
+2011, 15 de Febrero    ,25.693668,-100.235192, Ejecutan y se llevan cuerpo ,1,0,0,0,0
+2011, 15 de Febrero    ,25.652049,-100.201149, Narcobloqueo en Guadalupe. ,0,0,0,0,0
+2011, 15 de Febrero    ,25.692276,-100.184669, Narcobloqueos en la Autopista a Cadereyta ,0,0,0,0,0
+2011, 14 de Febrero    ,25.684139,-100.250999, Capturan a capo de zona citr&#237;cola ,0,0,3,0, Drogas Armas Vehículos 
+2011, 9 de Febrero    ,25.677463,-100.268247, Asesinan y comando se lleva cuerpo ,1,0,0,0,0
+2011, 8 de Febrero    ,25.65644,-100.220772, Aseguran soldados balas en camioneta ,0,0,0,0, Armas Vehículos 
+2011, 7 de Febrero    ,25.665018,-100.259643, Ejecutan y encobijan; lo avandonan en auto ,1,0,0,0, Vehículos 
+2011, 5 de Febrero    ,25.66055,-100.246661, Detiene a capo Yahir ,0,0,15,0, Armas Vehículos 
+2011, 25 de Febrero    ,25.656943,-100.173533, Intenta molestar a mujer; esposo lo mata a golpes ,1,0,0,0,0
+2011, 24 de Febrero    ,25.753027,-100.240736, Caen 3 secuestradores ,0,0,3,0,0
+2011, 19 de Febrero    ,25.801128,-100.245609, Muerte torturado a golpes ,1,0,0,0,0
+2011, 15 de Febrero    ,25.701557,-100.225525, Narcobloqueos en Apodaca ,0,0,0,0,0
+2011, 15 de Febrero    ,25.705614,-100.161476, Narcobloqueos en Apodaca ,0,0,0,0,0
+2011, 7 de Febrero    ,25.781562,-100.187597, Lanzan granada en Cereso de Apodaca ,0,0,0,0,0
+2011, 7 de Febrero    ,25.728023,-100.178448, Captura Federal a 6 polic&#237;as de Apodaca ,0,0,9,0, Drogas Armas 
+2011, 1 de Febrero    ,25.732604,-100.191278, Muere federal en enfrentamiento ,1,4,0,0,0
+2011, 8 de Febrero    ,25.766794,-100.327578, Hallan Veh&#237;culo con droga ,0,0,0,0, Drogas Armas Vehículos 
+2011, 9 de Febrero    ,25.984897,-100.139008, Aseguran armamento ,0,0,0,0, Armas 
+2011, 26 de Febrero    ,25.808921,-100.597923, Disparan afuera de casa de jefe policiaco ,0,0,0,0,0
+2011, 25 de Febrero    ,25.77489,-100.431776, Intentan ejecutar a Alcalde ,3,0,2,0, Armas Vehículos 
+2011, 25 de Febrero    ,25.808921,-100.597923, Atacan a polic&#237;as en Garc&#237;a ,0,0,0,0,0
+2011, 20 de Febrero    ,25.753517,-100.507393, Roba Comando 6 autos de empresa ,0,2,0,0,0
+2011, 12 de Febrero    ,25.779334,-100.450401, Capturan a 4 con droga en Garc&#237;a ,0,0,3,0, Drogas 
+2011, 5 de Febrero    ,25.660715,-100.714417, Aseguran mariguana en doble fondo ,0,0,1,0, Drogas 
+2011, 27 de Febrero    ,25.693861,-100.448513, Abate Ej&#233;rcito a 3  ,3,0,0,0, Armas 
+2011, 8 de Febrero    ,25.692972,-100.494475, Capturan a 7 narcos ,0,0,7,0, Armas Vehículos 
+2011, 8 de Febrero    ,25.67432,-100.426508, Detienen a 4 oficiales de S. Catarina por halconeo ,0,0,4,0,0
+2011, 1 de Febrero    ,25.690323,-100.453942, Mueren 3 sicarios en enfrentamiento ,3,0,2,0, Drogas Armas Vehículos 
+2011, 12 de Febrero    ,25.423899,-100.147205, Capturan a 4 narcomenudistas ,0,0,4,0, Drogas Armas Vehículos 
+2011, 4 de Febrero    ,25.451921,-100.151434, Torturan y ejecutan en Santiago ,1,0,0,0,0
+2011, 27 de Febrero    ,25.283471,-100.01979, Mata comando a 2 polic&#237;as ,2,0,0,0,0
+2011, 1 de Febrero    ,25.299004,-100.03358, Ejecutan a polic&#237;a de Allende ,1,1,0,0,0
+2011, 8 de Febrero    ,25.25382,-99.678077, Abaten a 3 en Ter&#225;n ,3,0,0,0, Armas 
+2011, 14 de Febrero    ,25.703331,-99.236522, Tiran cabeza frente a escuela ,1,0,0,0,0
+2011, 12 de Febrero    ,25.703331,-99.236522, Asegura Ej&#233;rcito arsenal ,0,0,0,0, Armas 
+2011, 24 de Febrero    ,25.585239,-99.998573, Abaten a sicarios; salvan a plagiados ,4,0,0,2,0
+2011, 13 de Febrero    ,25.585239,-99.998573, Tiran a un ejecutado en Cadereyta ,1,0,0,0, Armas 
+2011, 11 de Febrero    ,20.70217,-99.821777, Encuentran muerto en Cadereyta ,1,0,0,0,0
+2011, 1 de Febrero    ,25.606856,-100.000305, Tiran 3 cabezas en Cadereyta ,3,0,0,0,0
+2011, 6 de Febrero    ,25.698735,-99.624754, Hallan 5 mutilados en Los Ramones ,5,0,0,0,0
+2011, 27 de Febrero    ,25.898144,-99.783669, Muere pistolero en tiroteo ,1,0,2,0,0
+2011, 10 de Febrero    ,26.044754,-99.638443, Caen halcones en Cerralvo  ,0,0,4,0,0
+2011, 8 de Febrero    ,26.08427,-99.615601, Detienen a tres sicarios ,0,0,3,0, Armas Vehículos Dinero 
+2011, 8 de Febrero    ,26.506905,-100.179453, Decomisa Ej&#233;rcito arsenal ,0,0,0,0, Armas Vehículos 
+2011, 8 de Febrero    ,26.506905,-100.179453, Captura Ej&#233;rcito cuatro halcones ,0,0,4,0,0
+2011, 4 de Febrero    ,26.506905,-100.179453, Abaten a 2 en Sabinas ,2,0,3,0,0
+2011, 24 de Febrero    ,27.049647,-100.49057, Acribillan a 2 polic&#237;as ,2,0,0,0,0
+2011, 10 de Enero      ,25.652088,-100.339336, Asalta a escolta de vocero de Seguridad estatal ,0,1,0,0,0
+2011, 9 de Enero      ,25.654138,-100.337985, Capturan Grupo de Reacci&#243;n a halc&#243;n ,0,0,1,0, Drogas 
+2011, 5 de Enero      ,25.649825,-100.33011, Balean patrulla en Valle Oriente ,0,0,0,0,0
+2011, 1 de Enero      ,25.658684,-100.347437, Hallan a ejecutado en Valle Oriente ,1,0,0,0,0
+2011, 26 de Enero      ,25.647326,-100.094528, Hallan ejecutado en brecha ,1,0,0,0,0
+2011, 30 de Enero      ,25.737282,-100.316763, Muere en enfrentamiento ,1,0,0,0,0
+2011, 27 de Enero      ,25.731373,-100.319954, Se enfrentan ministeriales y robacoches ,0,0,1,0,0
+2011, 23 de Enero      ,25.718686,-100.287473, Atacan a polic&#237;as; lesionan a 1 ,0,1,0,0,0
+2011, 18 de Enero      ,25.766851,-100.286121, Explota auto afuera del Cedeco ,0,0,0,0, Vehículos 
+2011, 18 de Enero      ,25.763547,-100.322385, Muere sospechoso en San Nicol&#225;s ,1,0,1,0,0
+2011, 13 de Enero      ,25.765924,-100.286121, Mutilan y dejan cad&#225;ver afuera del Cedeco ,1,0,0,0, Vehículos 
+2011, 10 de Enero      ,25.710499,-100.247036, Ejecutan a 3 polic&#237;as de San Nicol&#225;s ,3,0,0,0,0
+2011, 8 de Enero      ,25.741632,-100.297543, Cae ladr&#243;n y halc&#243;n ,0,0,1,0, Armas Vehículos 
+2011, 3 de Enero      ,25.746588,-100.259278, Detienen a 3 polic&#237;as de San Nicol&#225;s ,0,1,3,0,0
+2011, 31 de Enero      ,25.666652,-100.297043, Atacan otro ret&#233;n policiaco ,0,5,0,0,0
+2011, 29 de Enero      ,25.708072,-100.277066, Ejecutan a 2 tr&#225;nsitos regios ,2,0,0,0,0
+2011, 27 de Enero      ,25.667194,-100.28434, Atacan ret&#233;n con granadas ,0,2,0,0,0
+2011, 27 de Enero      ,25.731792,-100.342534, Hallan a celadora mutilada ,1,0,0,0,0
+2011, 27 de Enero      ,25.637503,-100.288525, Detiene ej&#233;rcito a sicarios ,0,0,2,0, Drogas Armas Vehículos 
+2011, 24 de Enero      ,25.631109,-100.283729, Alarma balacera en Sierra Ventana ,0,0,2,0,0
+2011, 24 de Enero      ,25.725143,-100.345602, Hiere a 3 reos granada en el Topo Chico ,0,3,0,0,0
+2011, 23 de Enero      ,25.673211,-100.309201, Cae con droga y arma ,0,0,0,0, Drogas Armas 
+2011, 22 de Enero      ,25.724456,-100.386865, Muere uno en balacera en Cumbres ,1,2,0,0,0
+2011, 22 de Enero      ,25.724292,-100.386146, Explota granada a ni&#241;os en Cumbres ,0,3,0,0,0
+2011, 21 de Enero      ,25.643093,-100.278997, Alarman balaceras y levant&#243;n ,0,0,0,0, Vehículos 
+2011, 20 de Enero      ,25.783517,-100.404632, Sorprenden a 11 halcones ,0,0,11,0, Vehículos 
+2011, 20 de Enero      ,25.765798,-100.370096, Estalla auto frente a la Estaci&#243;n Norte de Polic&#237;a ,0,0,0,0, Vehículos 
+2011, 18 de Enero      ,25.778716,-100.417228, Abate Ej&#233;rcito a 5 en La Alianza ,5,0,0,0, Vehículos 
+2011, 18 de Enero      ,25.762832,-100.371952, Libran polic&#237;as ataque a balazos ,0,0,0,0,0
+2011, 17 de Enero      ,25.69709,-100.284855, Muere inocente en balacera ,6,2,0,0,0
+2011, 17 de Enero      ,25.755662,-100.35706, Caen por atacar a polic&#237;as a balazos ,0,0,4,0, Armas 
+2011, 17 de Enero      ,25.632124,-100.286077, Matan a 3 hermanos en puesto de tacos ,3,0,0,0,0
+2011, 16 de Enero      ,25.69419,-100.351632, Balean a dos polic&#237;as estatales ,0,2,0,0,0
+2011, 16 de Enero      ,25.774542,-100.374151, Balean a 4; fallece 1 ,1,3,0,0,0
+2011, 15 de Enero      ,25.640211,-100.303459, Tiran a decapitado ,1,0,0,0,0
+2011, 14 de Enero      ,25.693436,-100.284126, Ejecutan a 3 en auto robado ,3,0,0,0, Vehículos 
+2011, 14 de Enero      ,25.53824,-100.205204, Tiran a ejecutado ,1,0,0,0,0
+2011, 13 de Enero      ,25.649283,-100.297472, Ejecutan a polic&#237;a estatal ,1,0,0,0, Vehículos 
+2011, 13 de Enero      ,25.649303,-100.297515, Mueren 3 en casa de seguridad ,3,0,0,0, Armas 
+2011, 11 de Enero      ,25.762523,-100.371695, Atacan con granadas cuartel policiaco ,0,0,0,0, Armas 
+2011, 11 de Enero      ,25.718647,-100.342705, Ejecutan a celador del Topo Chico ,1,2,0,0,0
+2011, 11 de Enero      ,25.642851,-100.312235, Hallan a ejecutado en Canteras ,1,0,0,0,0
+2011, 10 de Enero      ,25.67259,-100.332298, Mata empistolado a joven empresario ,1,0,0,0,0
+2011, 10 de Enero      ,25.724833,-100.342931, Ejecutan en Penal a Zar de la Pirater&#237;a ,1,0,0,0,0
+2011, 10 de Enero      ,25.637793,-100.273118, Atacan sucursal de EL NORTE ,0,0,0,0,0
+2011, 10 de Enero      ,25.647107,-100.307407, Levantan y ejecutan ,1,0,0,0,0
+2011, 9 de Enero      ,25.667764,-100.29125, Ejecutan a narcovendedor ,2,0,0,0, Drogas Armas 
+2011, 7 de Enero      ,25.653055,-100.277324, Ejecutan a tr&#225;nsito regio ,1,1,0,0,0
+2011, 6 de Enero      ,25.686107,-100.316892, Caen 4 por venta de droga ,0,0,4,0, Vehículos 
+2011, 6 de Enero      ,25.725529,-100.345473, Atacan Penal del Topo Chico ,0,0,0,0, Armas 
+2011, 5 de Enero      ,25.672377,-100.359528, Tiran a ejecutado afuera de despacho ,1,0,0,0,0
+2011, 4 de Enero      ,25.653152,-100.262883, Tiran a barranco a levantados ,1,1,0,1,0
+2011, 3 de Enero      ,25.752618,-100.354335, Ejecutan a 3 y lesionan a otros 3 ,3,3,0,0,0
+2011, 27 de Enero      ,25.676167,-100.315304, Muere mesera apu&#241;alada en bar ,1,0,0,0,0
+2011, 27 de Enero      ,25.668141,-100.301871, Mata en plieto en los Condominios Constituci&#243;n ,1,0,0,0,0
+2011, 26 de Enero      ,25.682762,-100.341825, Asesina a su esposa en la Col. Chepevera ,1,0,0,0,0
+2011, 6 de Enero      ,25.685363,-100.310165, Mata a tr&#225;nsito empleado de sex shop ,1,0,0,0,0
+2011, 3 de Enero      ,25.584756,-100.257014, Asfixian y tiran cuerpo atr&#225;s de iglesia ,1,0,0,0,0
+2011, 26 de Enero      ,25.780725,-100.05043, Hallan ejecutados en pante&#243;n ,3,0,0,0,0
+2011, 23 de Enero      ,25.785,-100.051111, Detienen a tres en Pesquer&#237;a ,0,0,3,0, Drogas Armas Vehículos 
+2011, 27 de Enero      ,25.644621,-100.170593, Atacan a escoltas policiacas ,0,0,0,0,0
+2011, 27 de Enero      ,25.6793,-100.24533, Levantan y ejecutan a empresario y l&#237;der ganadero ,1,0,0,0,0
+2011, 20 de Enero      ,25.652538,-100.166044, Ejecutan a 5 frente a escuela ,5,0,0,0,0
+2011, 19 de Enero      ,25.662455,-100.170872, Mueren 4 en enfrentamiento ,4,0,1,0, Armas Vehículos 
+2011, 19 de Enero      ,25.683535,-100.261123, Cae ejecutor de polic&#237;as de Guadalupe ,0,1,1,0, Armas Vehículos 
+2011, 19 de Enero      ,25.679745,-100.250459, Acribillan a 2 Polic&#237;as de Guadalupe ,2,0,0,0,0
+2011, 14 de Enero      ,25.669766,-100.238142, Muere al huir de sicarios ,1,0,0,0,0
+2011, 13 de Enero      ,25.722804,-100.1966, Abate Ej&#233;rcito a sospechoso ,1,0,0,0,0
+2011, 5 de Enero      ,25.709124,-100.184959, Muere polic&#237;a baleado 23 d&#237;as despu&#233;s ,1,0,0,0,0
+2011, 31 de Enero      ,25.787739,-100.246682, Calcinan a pareja en tambos ,2,0,0,0,0
+2011, 31 de Enero      ,25.763304,-100.242037, Ejecutan dentro de veh&#237;culo ,1,0,0,0,0
+2011, 29 de Enero      ,25.760494,-100.161989, Atacan Polic&#237;a de Apodaca ,0,0,0,0,0
+2011, 26 de Enero      ,25.748009,-100.201342, Ejecutan a dos tr&#225;nsitos ,2,0,0,0,0
+2011, 24 de Enero      ,25.781562,-100.187597, Muere en penal ejecutor de polic&#237;as ,1,0,0,0,0
+2011, 5 de Enero      ,25.749613,-100.227242, Ejecutan a Tr&#225;nsito de Apodaca ,1,0,0,0,0
+2011, 3 de Enero      ,25.763576,-100.169317, Detiene Marina a 5 en balacera ,0,0,5,0, Drogas Armas Vehículos 
+2011, 2 de Enero      ,25.77918,-100.20396, Matan a balazos a tr&#225;nsito de Apodaca ,1,1,0,0,0
+2011, 30 de Enero      ,25.819942,-100.337062, Calcinan a seis ,6,0,0,0,0
+2011, 25 de Enero      ,25.791845,-100.338553, Hallan camioneta y tabla de torturas ,0,0,0,0, Vehículos 
+2011, 24 de Enero      ,25.792535,-100.303617, Rescatan a balazos a un secuestrado ,0,0,0,1, Armas Vehículos 
+2011, 6 de Enero      ,25.892745,-100.106047, Mueren 2 sicarios en Zuazua ,2,1,0,0, Armas 
+2011, 24 de Enero      ,25.91181,-100.36191, Abaten al Comandante Lino ,3,0,0,0, Armas Vehículos 
+2011, 17 de Enero      ,25.936697,-100.362373, Torturan y ejecutan en El Carmen ,1,0,0,0,0
+2011, 28 de Enero      ,24.076559,-99.805298, Discute y mata a balazos a hermano ,1,0,0,0,0
+2011, 18 de Enero      ,24.85787,-99.566328, Explota auto en Polic&#237;a de Linares ,0,0,0,0, Vehículos 
+2011, 8 de Enero      ,24.85787,-99.566328, Caen secuestradores de taxista ,0,0,4,1, Armas 
+2011, 24 de Enero      ,25.741611,-100.51486, Ej&#233;rcito abate a sicario ,1,0,0,0, Armas Vehículos 
+2011, 23 de Enero      ,25.808921,-100.597923, Hallan 4 veh&#237;culos robados ,0,0,0,0, Vehículos 
+2011, 14 de Enero      ,25.808921,-100.597923, Hallan a encobijado ,1,0,0,0,0
+2011, 29 de Enero      ,25.799466,-100.591657, Lo descubren robando y asesina a patr&#243;n ,1,0,0,0,0
+2011, 29 de Enero      ,25.688795,-100.451474, Detienen federales a 2 polic&#237;as ,5,2,2,0,0
+2011, 7 de Enero      ,25.792608,-100.579126, Caen 4 tras persecuci&#243;n y balacera ,0,0,4,0, Vehículos 
+2011, 5 de Enero      ,25.68485,-100.442677, Hieren a 2 federales ,0,2,4,0,0
+2011, 31 de Enero      ,25.69564,-100.467138, Pierde la v&#237;ctima vida de incendio provocado ,4,0,0,0,0
+2011, 15 de Enero      ,25.689549,-100.416794, Discute con su pareja y mata a su beb&#233; ,1,0,0,0,0
+2011, 15 de Enero      ,25.39501,-100.134804, Lesionan a ministerial con granadas ,0,1,0,0,0
+2011, 7 de Enero      ,25.426964,-100.151683, Levantan y ejecutan a polic&#237;a de Santiago ,2,1,0,0,0
+2011, 5 de Enero      ,25.44901,-100.09901, Acribillan a dos j&#243;venes en veh&#237;culo ,2,2,0,0,0
+2011, 22 de Enero      ,25.283611,-100.020278, Abaten a 2 falsos ministeriales ,2,0,0,0, Armas Vehículos 
+2011, 3 de Enero      ,25.27592,-100.013609, Atacan la Polic&#237;a Ministerial en Allende ,0,0,0,0,0
+2011, 9 de Enero      ,25.283611,-100.020278, Roban y asesina en Allende ,1,0,0,0,0
+2011, 18 de Enero      ,25.183496,-99.829679, Hallan 5 descuartizados en Montemorelos ,5,0,0,0,0
+2011, 24 de Enero      ,25.25382,-99.678077, Descuartizan a polic&#237;as de Ter&#225;n ,3,0,0,0,0
+2011, 24 de Enero      ,25.25382,-99.678077, Mueren dos sicarios en Ter&#225;n ,2,0,0,0,0
+2011, 20 de Enero      ,25.25382,-99.678077, Atacan y roban Polic&#237;a de Ter&#225;n ,0,0,0,0,0
+2011, 9 de Enero      ,25.257253,-99.685585, Ataca Comando Presidencia de General Ter&#225;n ,0,5,0,0,0
+2011, 9 de Enero      ,25.25382,-99.678077, Atacan comandancia de General Ter&#225;n ,0,0,0,0,0
+2011, 31 de Enero      ,25.703331,-99.236522, Atacan sicarios centro de China ,1,10,1,0,0
+2011, 29 de Enero      ,25.710257,-99.250188, Dejan ejecutado en autopista ,2,0,0,0,0
+2011, 16 de Enero      ,25.706352,-99.239373, Balacera en China ,0,1,0,0, Vehículos 
+2011, 9 de Enero      ,25.703331,-99.236522, Ataca Palacio de Justicia de China ,0,0,0,0,0
+2011, 1 de Enero      ,25.703331,-99.236522, Caen con armas largas en auto robado ,0,0,2,0, Armas Vehículos 
+2011, 18 de Enero      ,25.792576,-99.178629, Hallan narcobodega ,0,0,0,0, Armas Vehículos 
+2011, 30 de Enero      ,25.440329,-99.993855, Torturan y ejecutan a uno ,1,0,0,0,0
+2011, 30 de Enero      ,25.561717,-100.01787, Tiran a ejecutado afuera de pante&#243;n ,1,0,0,0,0
+2011, 30 de Enero      ,25.575954,-100.016428, Encuentran granada frente a Presidencia municipal ,0,0,0,0,0
+2011, 24 de Enero      ,25.585239,-99.998573, Muere sicario y aseguran armas ,1,0,0,0, Armas Vehículos 
+2011, 13 de Enero      ,25.585239,-99.998573, Ejecutan a tr&#225;nsito de Cadereyta ,1,1,0,0,0
+2011, 2 de Enero      ,25.585239,-99.998573, Lanza granadas a Polic&#237;a de Cadereyta ,0,0,0,0,0
+2011, 19 de Enero      ,25.381564,-99.984512, Hallan muerto en brecha ,1,0,0,0,0
+2011, 19 de Enero      ,26.659711,-99.986935, Aseguran tonelada de mariguana ,0,0,0,0, Drogas Armas Vehículos 
+2011, 10 de Enero      ,26.506905,-100.179453, Detonan ganada frente a casa de hermano de Alcalde ,0,0,0,0,0
+2011, 14 de Enero      ,25.963892,-100.294217, Encuentra Ej&#233;rcito a 2 ejecutados ,2,0,0,0,0
+2011, 31 de Enero      ,27.025489,-100.370407, Asesinan a machetazos ,1,0,0,0,0


### PR DESCRIPTION
Datos del mapa 2011 que incluye los datos de Monterrey más otros datos que se encontraban en la página de El Norte, en este caso de otros lugares de México. Se eliminó la clasificación por municipios.